### PR TITLE
Add support for 'cline' client

### DIFF
--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -6,17 +6,28 @@ import {
 import { ConfigManager } from "../utils/config-manager.js"
 import { createListChoices } from "../utils/server-display.js"
 import inquirer from "inquirer"
+import { VALID_CLIENTS, type ValidClient } from "../constants.js"
 
-export async function inspect(): Promise<void> {
+export async function inspect(client: ValidClient): Promise<void> {
 	try {
-		const installedIds = ConfigManager.getInstalledServerIds()
+		// ensure client is valid
+		if (client && !VALID_CLIENTS.includes(client as ValidClient)) {
+			console.error(
+				chalk.red(
+					`Invalid client: ${client}\nValid clients are: ${VALID_CLIENTS.join(", ")}`,
+				),
+			)
+			process.exit(1)
+		}
+
+		const installedIds = ConfigManager.getInstalledServerIds(client)
 
 		if (installedIds.length === 0) {
 			console.log(chalk.yellow("\nNo MCP servers are currently installed."))
 			return
 		}
 
-		const config = ConfigManager.readConfig()
+		const config = ConfigManager.readConfig(client)
 
 		while (true) {
 			const choices = createListChoices(

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -7,7 +7,7 @@ const serverManager = new ServerManager()
 
 export async function install(
 	serverId: string,
-	client?: string,
+	client: ValidClient,
 ): Promise<void> {
 	// ensure client is valid
 	if (client && !VALID_CLIENTS.includes(client as ValidClient)) {
@@ -28,6 +28,6 @@ export async function install(
 	}
 
 	// install server using the serverManager instance
-	await serverManager.installServer(server)
-	console.log(chalk.green(`✓ Successfully installed package '${serverId}'`))
+	await serverManager.installServer(server, client)
+	console.log(chalk.green(`✓ Successfully installed package '${serverId}' for ${client}`))
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,11 +1,22 @@
 import chalk from "chalk"
 import inquirer from "inquirer"
 import { ServerManager } from "../utils/server-manager.js"
+import { VALID_CLIENTS, type ValidClient } from "../constants.js"
 
 const serverManager = new ServerManager()
 
-export async function uninstall(serverId?: string): Promise<void> {
+export async function uninstall(serverId: string, client: ValidClient): Promise<void> {
 	try {
+		// ensure client is valid
+		if (client && !VALID_CLIENTS.includes(client as ValidClient)) {
+			console.error(
+				chalk.red(
+					`Invalid client: ${client}\nValid clients are: ${VALID_CLIENTS.join(", ")}`,
+				),
+			)
+			process.exit(1)
+		}
+
 		// If no server name provided, show error
 		if (!serverId) {
 			console.error(chalk.red("Error: Server ID is required"))
@@ -31,13 +42,15 @@ export async function uninstall(serverId?: string): Promise<void> {
 		}
 
 		// Perform uninstallation
-		await serverManager.uninstallServer(serverId)
-		console.log(chalk.green(`\nSuccessfully uninstalled ${serverId}`))
-		console.log(
-			chalk.yellow(
-				"\nNote: Please restart Claude for the changes to take effect.",
-			),
-		)
+		await serverManager.uninstallServer(serverId, client)
+		console.log(chalk.green(`\nSuccessfully uninstalled ${serverId} for ${client}`))
+		if (client === "claude") {
+			console.log(
+				chalk.yellow(
+					"\nNote: Please restart Claude for the changes to take effect.",
+				),
+			)
+		}
 	} catch (error) {
 		console.error(chalk.red("Failed to uninstall server:"))
 		console.error(

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -2,10 +2,21 @@ import chalk from "chalk"
 import { resolveServer } from "../utils/registry-utils.js"
 import { handleServerAction } from "../utils/server-actions.js"
 import { displayServerDetails } from "../utils/server-display.js"
+import { VALID_CLIENTS, type ValidClient } from "../constants.js"
 
-export async function get(serverId: string) {
+export async function get(serverId: string, client: ValidClient) {
 	try {
-		const server = await resolveServer(serverId)
+		// ensure client is valid
+		if (client && !VALID_CLIENTS.includes(client as ValidClient)) {
+			console.error(
+				chalk.red(
+					`Invalid client: ${client}\nValid clients are: ${VALID_CLIENTS.join(", ")}`,
+				),
+			)
+			process.exit(1)
+		}
+
+		const server = await resolveServer(serverId, client)
 
 		if (!server) {
 			console.log(chalk.yellow(`No server found with ID: ${serverId}`))
@@ -13,7 +24,7 @@ export async function get(serverId: string) {
 		}
 
 		const action = await displayServerDetails(server, false)
-		await handleServerAction(server, action, {})
+		await handleServerAction(server, action, {}, false, client)
 	} catch (error) {
 		console.error(chalk.red("Error loading server:"))
 		if (error instanceof Error && error.message.includes("fetch")) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const VALID_CLIENTS = ["claude"] as const
+export const VALID_CLIENTS = ["claude", "cline"] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,21 @@ import { uninstall } from "./commands/uninstall.js"
 import { listInstalledServers } from "./commands/installed.js"
 import { get } from "./commands/view.js"
 import { inspect } from "./commands/inspect.js"
+import { type ValidClient } from "./constants.js"
+import chalk from "chalk"
 
 const command = process.argv[2]
 const packageName = process.argv[3]
 const clientFlag = process.argv.indexOf("--client")
-const client = clientFlag !== -1 ? process.argv[clientFlag + 1] : undefined
+const client = clientFlag !== -1 ? process.argv[clientFlag + 1] as ValidClient : "claude"
+if (clientFlag === -1) {
+	console.log(chalk.yellow("Client not provided, defaulting to claude"))
+}
 
 async function main() {
 	switch (command) {
 		case "inspect":
-			await inspect()
+			await inspect(client)
 			break
 		case "install":
 			if (!packageName) {
@@ -24,17 +29,17 @@ async function main() {
 			await install(packageName, client)
 			break
 		case "uninstall":
-			await uninstall(packageName)
+			await uninstall(packageName, client)
 			break
 		case "installed":
-			await listInstalledServers()
+			await listInstalledServers(client)
 			break
 		case "view":
 			if (!packageName) {
 				console.error("Please provide a package ID to get details")
 				process.exit(1)
 			}
-			await get(packageName)
+			await get(packageName, client)
 			break
 		default:
 			console.log("Available commands:")

--- a/src/utils/registry-utils.ts
+++ b/src/utils/registry-utils.ts
@@ -13,7 +13,7 @@ export const REGISTRY_ENDPOINT =
 	process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"
 
 export async function fetchServers(
-	client?: string,
+	client: string,
 	serverIds: string[] = [],
 ): Promise<ResolvedServer[]> {
 	try {
@@ -40,12 +40,12 @@ export async function fetchServers(
 // Returns null if server cannot be found in either location
 export async function resolveServer(
 	serverId: string,
-	client?: string,
+	client: string,
 ): Promise<ResolvedServer | null> {
 	try {
 		// Check if server is installed first
 		// const config = ConfigManager.readConfig()
-		const isInstalled = ConfigManager.isServerInstalled(serverId)
+		const isInstalled = ConfigManager.isServerInstalled(serverId, client)
 
 		const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverId}`)
 

--- a/src/utils/server-manager.ts
+++ b/src/utils/server-manager.ts
@@ -4,6 +4,7 @@ import type { ConnectionDetails } from "../types/registry.js"
 import { getServerConfiguration } from "./registry-utils.js"
 import { promptForRestart } from "./client-utils.js"
 import { collectConfigValues } from "./runtime-utils.js"
+import { ValidClient } from "../constants.js"
 
 export class ServerManager {
 	private configManager: typeof ConfigManager
@@ -20,7 +21,7 @@ export class ServerManager {
 		return connection
 	}
 
-	async installServer(server: ResolvedServer): Promise<void> {
+	async installServer(server: ResolvedServer, client: ValidClient): Promise<void> {
 		const connection = this.validateConnection(server)
 		const values = await collectConfigValues(connection)
 		const serverConfig = await getServerConfiguration(
@@ -38,12 +39,12 @@ export class ServerManager {
 		await this.configManager.installServer(
 			server.id,
 			serverConfig,
-			server.client,
+			client,
 		)
-		await promptForRestart(server.client)
+		await promptForRestart(client)
 	}
 
-	async uninstallServer(serverId: string, client?: string): Promise<void> {
+	async uninstallServer(serverId: string, client: string): Promise<void> {
 		try {
 			await this.configManager.uninstallServer(serverId, client)
 			console.log(`\nUninstalled ${serverId}`)


### PR DESCRIPTION
This PR adds support for cline through --client flag.

Users can now manage servers for cline by adding '--client cline' to existing commands. If no client is specified, we default to 'claude' with the following message to user: "Client not provided, defaulting to claude"

Might add better ways to manage servers across clients in the future, for example, to allow user to select from identified clients from options if none specified. Additionally, might need to think of a better user flow when using the inspect, view commands (since they aren't too client dependent).