### PR TITLE
Add 'run' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The Smithery registry installer and manager for Model Context Protocol (MCP) servers, designed to be client-agnostic.
 
+## Requirements
+- NodeJS version 18 or above
+
 ## Usage
 
 ```bash

--- a/build.mjs
+++ b/build.mjs
@@ -12,5 +12,4 @@ await esbuild.build({
 	minify: true,
 	treeShaking: true,
 	outfile: "dist/index.js",
-	define: {},
 })

--- a/build.mjs
+++ b/build.mjs
@@ -8,7 +8,7 @@ await esbuild.build({
 	entryPoints: ["src/index.ts"],
 	bundle: true,
 	platform: "node",
-	target: "node16",
+	target: "node18",
 	minify: true,
 	treeShaking: true,
 	outfile: "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,6 +1417,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -1714,7 +1715,8 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
@@ -2285,12 +2287,14 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.5",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.0.3",
+				"@smithery/sdk": "^0.0.22",
 				"chalk": "^4.1.2",
 				"inquirer": "^8.2.4",
 				"inquirer-autocomplete-prompt": "^2.0.0"
@@ -27,6 +28,28 @@
 				"ts-node": "^10.9.1",
 				"tsx": "^4.19.2",
 				"typescript": "^5.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.32.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.32.1.tgz",
+			"integrity": "sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg==",
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+			"version": "18.19.71",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
+			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -590,6 +613,14 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@icons-pack/react-simple-icons": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-10.2.0.tgz",
+			"integrity": "sha512-QDUxup8D3GdIIzwGpxQs6bjeFV5mJes25qqf4aqP/PaBYQNCar7AiyD8C14636TosCG0A/QqAUwm/Hviep4d4g==",
+			"peerDependencies": {
+				"react": "^16.13 || ^17 || ^18 || ^19"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -606,13 +637,28 @@
 			"dev": true
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.3.tgz",
-			"integrity": "sha512-2as3cX/VJ0YBHGmdv3GFyTpoM8q2gqE98zh3Vf1NwnsSY0h3mvoO07MUzfygCKkWsFjcZm4otIiqD6Xh7kiSBQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.1.tgz",
+			"integrity": "sha512-siCApQgBn3U8R93TdumLtezRyRIlrA/a63GrTRO1jP31fRyOohpu0iPLvXzsyptxmy7B8GDxr8+r+Phu6mHgzg==",
 			"dependencies": {
 				"content-type": "^1.0.5",
 				"raw-body": "^3.0.0",
 				"zod": "^3.23.8"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@smithery/sdk": {
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/@smithery/sdk/-/sdk-0.0.22.tgz",
+			"integrity": "sha512-Df/3Yozwb1ATc/tJyCXjBEhT0S6KWkE311ZFtcg5bePb/bZSuFPQnmKS2VmDkS1pqHIfy+JXIYWeHGHYgmHpwQ==",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.32.1",
+				"@icons-pack/react-simple-icons": "^10.2.0",
+				"@modelcontextprotocol/sdk": "^1.1.1",
+				"openai": "^4.0.0",
+				"uuid": "^11.0.3"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -667,8 +713,16 @@
 		"node_modules/@types/node": {
 			"version": "14.18.63",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+			"integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^4.0.0"
+			}
 		},
 		"node_modules/@types/through": {
 			"version": "0.0.33",
@@ -677,6 +731,17 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
 			}
 		},
 		"node_modules/acorn": {
@@ -701,6 +766,17 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -744,6 +820,11 @@
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -879,6 +960,17 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/content-type": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -902,6 +994,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/depd": {
@@ -985,6 +1085,14 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1010,6 +1118,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data-encoder": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+		},
+		"node_modules/formdata-node": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+			"dependencies": {
+				"node-domexception": "1.0.0",
+				"web-streams-polyfill": "4.0.0-beta.3"
+			},
+			"engines": {
+				"node": ">= 12.20"
 			}
 		},
 		"node_modules/fsevents": {
@@ -1059,6 +1197,14 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"dependencies": {
+				"ms": "^2.0.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -1192,6 +1338,25 @@
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1200,10 +1365,52 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
 		"node_modules/mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
@@ -1217,6 +1424,43 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openai": {
+			"version": "4.79.1",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.79.1.tgz",
+			"integrity": "sha512-M7P5/PKnT/S/B5v0D64giC9mjyxFYkqlCuQFzR5hkdzMdqUuHf8T1gHhPGPF5oAvu4+PO3TvJv/qhZoS2bqAkw==",
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			},
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openai/node_modules/@types/node": {
+			"version": "18.19.71",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
+			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/ora": {
@@ -1275,6 +1519,15 @@
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react": {
+			"version": "19.0.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+			"integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1437,6 +1690,11 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
@@ -1952,6 +2210,11 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1965,6 +2228,18 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
+		"node_modules/uuid": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1977,6 +2252,28 @@
 			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
 			"dependencies": {
 				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "4.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+			"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@modelcontextprotocol/sdk": "^1.0.3",
 				"@smithery/sdk": "^0.0.22",
 				"chalk": "^4.1.2",
+				"eventsource": "^3.0.2",
 				"inquirer": "^8.2.4",
 				"inquirer-autocomplete-prompt": "^2.0.0"
 			},
@@ -1091,6 +1092,25 @@
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.2.tgz",
+			"integrity": "sha512-YolzkJNxsTL3tCJMWFxpxtG2sCjbZ4LQUBUrkdaJK0ub0p6lmJt+2+1SwhKjLc652lpH9L/79Ptez972H9tphw==",
+			"dependencies": {
+				"eventsource-parser": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+			"integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/external-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@smithery/sdk": "^0.0.22",
 				"chalk": "^4.1.2",
 				"eventsource": "^3.0.2",
+				"eventsource-polyfill": "^0.9.6",
 				"inquirer": "^8.2.4",
 				"inquirer-autocomplete-prompt": "^2.0.0"
 			},
@@ -24,11 +25,16 @@
 				"@types/inquirer-autocomplete-prompt": "^3.0.3",
 				"@types/json-schema": "^7.0.15",
 				"@types/node": "^14.0.0",
+				"@types/node-fetch": "^2.6.12",
 				"dotenv": "^16.4.7",
 				"esbuild": "^0.24.0",
+				"node-fetch": "^2.7.0",
 				"ts-node": "^10.9.1",
 				"tsx": "^4.19.2",
 				"typescript": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=21.0.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -720,6 +726,7 @@
 			"version": "2.6.12",
 			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
 			"integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"form-data": "^4.0.0"
@@ -1112,6 +1119,12 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
+		},
+		"node_modules/eventsource-polyfill": {
+			"version": "0.9.6",
+			"resolved": "https://registry.npmjs.org/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz",
+			"integrity": "sha512-LyMFp2oPDGhum2lMvkjqKZEwWd2/AoXyt8aoyftTBMWwPHNgU+2tdxhTHPluDxoz+z4gNj0uHAPR9nqevATMbg==",
+			"license": "MIT"
 		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@modelcontextprotocol/sdk": "^1.0.3",
 		"@smithery/sdk": "^0.0.22",
 		"chalk": "^4.1.2",
+		"eventsource": "^3.0.2",
 		"inquirer": "^8.2.4",
 		"inquirer-autocomplete-prompt": "^2.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -40,11 +40,7 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.0.0"
 	},
-	"files": [
-		"dist",
-		"README.md",
-		"package.json"
-	],
+	"files": ["dist", "README.md", "package.json"],
 	"exports": {
 		".": {
 			"import": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,17 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.0.0"
 	},
-	"files": ["dist", "README.md", "package.json"],
+	"files": [
+		"dist",
+		"README.md",
+		"package.json"
+	],
 	"exports": {
 		".": {
 			"import": "./dist/index.js"
 		}
+	},
+	"engines": {
+		"node": ">=18.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.0.3",
+		"@smithery/sdk": "^0.0.22",
 		"chalk": "^4.1.2",
 		"inquirer": "^8.2.4",
 		"inquirer-autocomplete-prompt": "^2.0.0"

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import {
+  ClientRequest,
+  ServerCapabilities,
+} from '@modelcontextprotocol/sdk/types.js'
+import { EventSource } from "eventsource"
+import { z } from 'zod'
+import { HandlerManager } from '../utils/mcp-handlers.js'
+global.EventSource = EventSource as any
+
+// Modified to remove client parameter
+export async function run(serverId: string) {
+    // For now using dummy URL - will be replaced with registry lookup
+    const sseUrl = `https://ddc7b706-b403-4217-8df7-dd7a065eae4d-5u5fdnfupa-uc.a.run.app/sse`
+    const config = {} // Placeholder empty config
+    
+    const server = new GatewayServer()
+    try {
+        await server.run(sseUrl)
+    } catch (error) {
+        console.error('[Gateway] Fatal error:', error)
+        process.exit(1)
+    }
+}
+
+class GatewayServer {
+  private server!: Server
+  private sseClient: Client
+  private handlerManager!: HandlerManager
+  private closing = false
+  private requestTimeout = 10000 // 10 seconds default timeout
+  
+  constructor() {
+    this.closing = false
+    
+    this.sseClient = new Client(
+      { name: 'smithery-runner', version: '1.0.0' },
+      { capabilities: {} }
+    )
+  }
+
+  private async makeRequest<T extends z.ZodType>(request: ClientRequest, schema: T) {
+    if (!this.sseClient) {
+      throw new Error("Client not connected");
+    }
+
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      abortController.abort("Request timed out");
+    }, this.requestTimeout);
+
+    try {
+      const response = await this.sseClient.request(request, schema, {
+        signal: abortController.signal,
+      });
+      return response;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async setupHandlers(remoteCapabilities: ServerCapabilities): Promise<void> {
+    this.handlerManager = new HandlerManager(
+      this.server,
+      this.sseClient,
+      this.makeRequest.bind(this)
+    )
+    await this.handlerManager.setupHandlers(remoteCapabilities)
+  }
+
+  private setupErrorHandling(): void {
+    this.server.onerror = (error) => {
+      console.error('[Gateway] Server error:', error)
+      if (!this.closing) {
+        this.cleanup().catch(err => {
+          console.error('[Gateway] Cleanup error during error handling:', err)
+        })
+      }
+    }
+
+    this.sseClient.onerror = (error) => {
+      console.error('[Gateway] SSE client error:', error)
+      if (!this.closing) {
+        this.cleanup().catch(err => {
+          console.error('[Gateway] Cleanup error during error handling:', err)
+        })
+      }
+    }
+
+    this.server.onclose = () => {
+      console.error('[Gateway] Server closed')
+      if (!this.closing) {
+        this.cleanup().catch(err => {
+          console.error('[Gateway] Cleanup error during close:', err)
+        })
+      }
+    }
+
+    this.sseClient.onclose = () => {
+      console.error('[Gateway] SSE client closed')
+      if (!this.closing) {
+        this.cleanup().catch(err => {
+          console.error('[Gateway] Cleanup error during close:', err)
+        })
+      }
+    }
+
+    process.on('SIGINT', () => this.cleanup())
+    process.on('SIGTERM', () => this.cleanup())
+  }
+
+  private async cleanup(): Promise<void> {
+    if (this.closing) {
+      return
+    }
+
+    this.closing = true
+    console.error('[Gateway] Starting cleanup...')
+
+    try {
+      if (this.sseClient) {
+        console.error('[Gateway] Closing SSE client...')
+        await this.sseClient.close()
+      }
+
+      if (this.server) {
+        console.error('[Gateway] Closing server...')
+        await this.server.close()
+      }
+
+      console.error('[Gateway] Cleanup completed')
+      process.exit(0)
+    } catch (error) {
+      console.error('[Gateway] Fatal error during cleanup:', error)
+      process.exit(1)
+    }
+  }
+
+  async run(sseUrl: string): Promise<void> {
+    try {
+      // Connect SSE client first to discover capabilities
+      const sseTransport = new SSEClientTransport(new URL(sseUrl))
+      await this.sseClient.connect(sseTransport)
+      console.error('[Gateway] Connected to remote SSE server')
+
+      // Get capabilities
+      const capabilities = this.sseClient.getServerCapabilities() || {}
+      console.error('[Gateway] Remote server capabilities:', capabilities)
+
+      // Create server with the discovered capabilities
+      this.server = new Server(
+        { name: 'smithery-runner', version: '1.0.0' },
+        { capabilities }
+      )
+
+      // Set up error handling
+      this.setupErrorHandling()
+
+      // Set up handlers based on remote capabilities
+      await this.setupHandlers(capabilities)
+
+      // Finally connect local STDIO server
+      const stdioTransport = new StdioServerTransport()
+      await this.server.connect(stdioTransport)
+      console.error('[Gateway] STDIO server ready')
+
+    } catch (error) {
+      console.error('[Gateway] Setup error:', error)
+      await this.cleanup()
+      throw error
+    }
+  }
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,177 +1,30 @@
 #!/usr/bin/env node
-import { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
-import {
-  ClientRequest,
-  ServerCapabilities,
-} from '@modelcontextprotocol/sdk/types.js'
 import { EventSource } from "eventsource"
-import { z } from 'zod'
-import { HandlerManager } from '../utils/mcp-handlers.js'
+import { GatewayServer } from '../services/gateway-server.js'
+import { resolveServer } from '../utils/registry-utils.js'
+
 global.EventSource = EventSource as any
 
-// Modified to remove client parameter
-export async function run(serverId: string) {
-    // For now using dummy URL - will be replaced with registry lookup
-    const sseUrl = `https://ddc7b706-b403-4217-8df7-dd7a065eae4d-5u5fdnfupa-uc.a.run.app/sse`
-    const config = {} // Placeholder empty config
-    
-    const server = new GatewayServer()
+// takes server id and config json to run server
+// routes between STDIO and SSE based on available connection
+export async function run(serverId: string, config: Record<string, unknown>) {
     try {
-        await server.run(sseUrl)
+        // Look up server details from registry
+        const resolvedServer = await resolveServer(serverId)
+        if (!resolvedServer) {
+            throw new Error(`Could not resolve server: ${serverId}`)
+        }
+
+        console.error('[Runner] Resolved server details:', {
+            id: resolvedServer.id,
+            connectionTypes: resolvedServer.connections.map(c => c.type)
+        })
+
+        const server = new GatewayServer()
+        await server.run(resolvedServer, config)
     } catch (error) {
-        console.error('[Gateway] Fatal error:', error)
+        console.error('[Runner] Fatal error:', error)
         process.exit(1)
     }
 }
 
-class GatewayServer {
-  private server!: Server
-  private sseClient: Client
-  private handlerManager!: HandlerManager
-  private closing = false
-  private requestTimeout = 10000 // 10 seconds default timeout
-  
-  constructor() {
-    this.closing = false
-    
-    this.sseClient = new Client(
-      { name: 'smithery-runner', version: '1.0.0' },
-      { capabilities: {} }
-    )
-  }
-
-  private async makeRequest<T extends z.ZodType>(request: ClientRequest, schema: T) {
-    if (!this.sseClient) {
-      throw new Error("Client not connected");
-    }
-
-    const abortController = new AbortController();
-    const timeoutId = setTimeout(() => {
-      abortController.abort("Request timed out");
-    }, this.requestTimeout);
-
-    try {
-      const response = await this.sseClient.request(request, schema, {
-        signal: abortController.signal,
-      });
-      return response;
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }
-
-  private async setupHandlers(remoteCapabilities: ServerCapabilities): Promise<void> {
-    this.handlerManager = new HandlerManager(
-      this.server,
-      this.sseClient,
-      this.makeRequest.bind(this)
-    )
-    await this.handlerManager.setupHandlers(remoteCapabilities)
-  }
-
-  private setupErrorHandling(): void {
-    this.server.onerror = (error) => {
-      console.error('[Gateway] Server error:', error)
-      if (!this.closing) {
-        this.cleanup().catch(err => {
-          console.error('[Gateway] Cleanup error during error handling:', err)
-        })
-      }
-    }
-
-    this.sseClient.onerror = (error) => {
-      console.error('[Gateway] SSE client error:', error)
-      if (!this.closing) {
-        this.cleanup().catch(err => {
-          console.error('[Gateway] Cleanup error during error handling:', err)
-        })
-      }
-    }
-
-    this.server.onclose = () => {
-      console.error('[Gateway] Server closed')
-      if (!this.closing) {
-        this.cleanup().catch(err => {
-          console.error('[Gateway] Cleanup error during close:', err)
-        })
-      }
-    }
-
-    this.sseClient.onclose = () => {
-      console.error('[Gateway] SSE client closed')
-      if (!this.closing) {
-        this.cleanup().catch(err => {
-          console.error('[Gateway] Cleanup error during close:', err)
-        })
-      }
-    }
-
-    process.on('SIGINT', () => this.cleanup())
-    process.on('SIGTERM', () => this.cleanup())
-  }
-
-  private async cleanup(): Promise<void> {
-    if (this.closing) {
-      return
-    }
-
-    this.closing = true
-    console.error('[Gateway] Starting cleanup...')
-
-    try {
-      if (this.sseClient) {
-        console.error('[Gateway] Closing SSE client...')
-        await this.sseClient.close()
-      }
-
-      if (this.server) {
-        console.error('[Gateway] Closing server...')
-        await this.server.close()
-      }
-
-      console.error('[Gateway] Cleanup completed')
-      process.exit(0)
-    } catch (error) {
-      console.error('[Gateway] Fatal error during cleanup:', error)
-      process.exit(1)
-    }
-  }
-
-  async run(sseUrl: string): Promise<void> {
-    try {
-      // Connect SSE client first to discover capabilities
-      const sseTransport = new SSEClientTransport(new URL(sseUrl))
-      await this.sseClient.connect(sseTransport)
-      console.error('[Gateway] Connected to remote SSE server')
-
-      // Get capabilities
-      const capabilities = this.sseClient.getServerCapabilities() || {}
-      console.error('[Gateway] Remote server capabilities:', capabilities)
-
-      // Create server with the discovered capabilities
-      this.server = new Server(
-        { name: 'smithery-runner', version: '1.0.0' },
-        { capabilities }
-      )
-
-      // Set up error handling
-      this.setupErrorHandling()
-
-      // Set up handlers based on remote capabilities
-      await this.setupHandlers(capabilities)
-
-      // Finally connect local STDIO server
-      const stdioTransport = new StdioServerTransport()
-      await this.server.connect(stdioTransport)
-      console.error('[Gateway] STDIO server ready')
-
-    } catch (error) {
-      console.error('[Gateway] Setup error:', error)
-      await this.cleanup()
-      throw error
-    }
-  }
-}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,30 +1,29 @@
 #!/usr/bin/env node
 import { EventSource } from "eventsource"
-import { GatewayServer } from '../services/gateway-server.js'
-import { resolveServer } from '../utils/registry-utils.js'
+import { GatewayServer } from "../services/gateway-server.js"
+import { resolveServer } from "../utils/registry-utils.js"
 
 global.EventSource = EventSource as any
 
 // takes server id and config json to run server
 // routes between STDIO and SSE based on available connection
 export async function run(serverId: string, config: Record<string, unknown>) {
-    try {
-        // Look up server details from registry
-        const resolvedServer = await resolveServer(serverId)
-        if (!resolvedServer) {
-            throw new Error(`Could not resolve server: ${serverId}`)
-        }
+	try {
+		// Look up server details from registry
+		const resolvedServer = await resolveServer(serverId)
+		if (!resolvedServer) {
+			throw new Error(`Could not resolve server: ${serverId}`)
+		}
 
-        console.error('[Runner] Resolved server details:', {
-            id: resolvedServer.id,
-            connectionTypes: resolvedServer.connections.map(c => c.type)
-        })
+		console.error("[Runner] Resolved server details:", {
+			id: resolvedServer.id,
+			connectionTypes: resolvedServer.connections.map((c) => c.type),
+		})
 
-        const server = new GatewayServer()
-        await server.run(resolvedServer, config)
-    } catch (error) {
-        console.error('[Runner] Fatal error:', error)
-        process.exit(1)
-    }
+		const server = new GatewayServer()
+		await server.run(resolvedServer, config)
+	} catch (error) {
+		console.error("[Runner] Fatal error:", error)
+		process.exit(1)
+	}
 }
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,6 @@
 export const VALID_CLIENTS = ["claude", "cline", "roo-cline"] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
+
+export const REGISTRY_ENDPOINT = process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"
+// export const REGISTRY_ENDPOINT = "http://localhost:3000/registry" // local testing
+

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 export const VALID_CLIENTS = ["claude", "cline", "roo-cline"] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
 
-export const REGISTRY_ENDPOINT = process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"
-// export const REGISTRY_ENDPOINT = "http://localhost:3000/registry" // local testing
-
+export const REGISTRY_ENDPOINT =
+	process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ const command = process.argv[2]
 const packageName = process.argv[3]
 const clientFlag = process.argv.indexOf("--client")
 const configFlag = process.argv.indexOf("--config")
-const client = clientFlag !== -1 ? (process.argv[clientFlag + 1] as ValidClient) : "claude"
+const client =
+	clientFlag !== -1 ? (process.argv[clientFlag + 1] as ValidClient) : "claude"
 const config = configFlag !== -1 ? JSON.parse(process.argv[configFlag + 1]) : {}
 
 // if (clientFlag === -1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,13 @@ import chalk from "chalk"
 const command = process.argv[2]
 const packageName = process.argv[3]
 const clientFlag = process.argv.indexOf("--client")
-const client =
-	clientFlag !== -1 ? (process.argv[clientFlag + 1] as ValidClient) : "claude"
-if (clientFlag === -1) {
-	console.log(chalk.yellow("Client not provided, defaulting to claude"))
-}
+const configFlag = process.argv.indexOf("--config")
+const client = clientFlag !== -1 ? (process.argv[clientFlag + 1] as ValidClient) : "claude"
+const config = configFlag !== -1 ? JSON.parse(process.argv[configFlag + 1]) : {}
+
+// if (clientFlag === -1) {
+// 	console.log(chalk.yellow("Client not provided, defaulting to claude"))
+// }
 
 async function main() {
 	switch (command) {
@@ -27,6 +29,9 @@ async function main() {
 			if (!packageName) {
 				console.error("Please provide a package name to install")
 				process.exit(1)
+			}
+			if (clientFlag === -1) {
+				console.log(chalk.yellow("Client not provided, defaulting to claude"))
 			}
 			await install(packageName, client)
 			break
@@ -48,7 +53,7 @@ async function main() {
 				console.error("Please provide a server ID to run")
 				process.exit(1)
 			}
-			await run(packageName)
+			await run(packageName, config)
 			break
 		default:
 			console.log("Available commands:")

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { uninstall } from "./commands/uninstall.js"
 import { listInstalledServers } from "./commands/installed.js"
 import { get } from "./commands/view.js"
 import { inspect } from "./commands/inspect.js"
+import { run } from "./commands/run.js"
 import type { ValidClient } from "./constants.js"
 import chalk from "chalk"
 
@@ -42,6 +43,13 @@ async function main() {
 			}
 			await get(packageName, client)
 			break
+		case "run":
+			if (!packageName) {
+				console.error("Please provide a server ID to run")
+				process.exit(1)
+			}
+			await run(packageName)
+			break
 		default:
 			console.log("Available commands:")
 			console.log("  install <package>     Install a package")
@@ -50,6 +58,7 @@ async function main() {
 			console.log("  installed             List installed packages")
 			console.log("  view <package>        Get details for a specific package")
 			console.log("  inspect               Inspect installed servers")
+			console.log("  run <server-id>       Run a server")
 			process.exit(1)
 	}
 }

--- a/src/services/gateway-server.ts
+++ b/src/services/gateway-server.ts
@@ -1,0 +1,326 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { ClientRequest, ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { HandlerManager } from '../utils/mcp-handlers.js'
+import { ResolvedServer, ConfiguredStdioServer } from '../types/registry.js'
+import { spawn } from 'child_process'
+import { createSmitheryUrl } from "@smithery/sdk/config.js"
+import { collectConfigValues } from '../utils/runtime-utils.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+export const REGISTRY_ENDPOINT = process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"
+
+export class GatewayServer {
+    private server!: Server
+    private client: Client
+    private handlerManager!: HandlerManager
+    private closing = false
+    private requestTimeout = 10000 // 10 seconds default timeout
+    
+    constructor() {
+      this.closing = false
+      
+      this.client = new Client(
+        { name: 'smithery-runner', version: '1.0.0' },
+        { capabilities: {} }
+      )
+    }
+  
+    private async makeRequest<T extends z.ZodType>(request: ClientRequest, schema: T) {
+      if (!this.client) {
+        throw new Error("Client not connected");
+      }
+  
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => {
+        abortController.abort("Request timed out");
+      }, this.requestTimeout);
+  
+      try {
+        const response = await this.client.request(request, schema, {
+          signal: abortController.signal,
+        });
+        return response;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+  
+    private async setupHandlers(remoteCapabilities: ServerCapabilities): Promise<void> {
+      this.handlerManager = new HandlerManager(
+        this.server,
+        this.client,
+        this.makeRequest.bind(this)
+      )
+      await this.handlerManager.setupHandlers(remoteCapabilities)
+    }
+  
+    private setupErrorHandling(): void {
+      this.server.onerror = (error) => {
+        console.error('[Gateway] Server error:', error)
+        if (!this.closing) {
+          this.cleanup().catch(err => {
+            console.error('[Gateway] Cleanup error during error handling:', err)
+          })
+        }
+      }
+  
+      this.client.onerror = (error) => {
+        console.error('[Gateway] SSE client error:', error)
+        if (!this.closing) {
+          this.cleanup().catch(err => {
+            console.error('[Gateway] Cleanup error during error handling:', err)
+          })
+        }
+      }
+  
+      this.server.onclose = () => {
+        console.error('[Gateway] Server closed')
+        if (!this.closing) {
+          this.cleanup().catch(err => {
+            console.error('[Gateway] Cleanup error during close:', err)
+          })
+        }
+      }
+  
+      this.client.onclose = () => {
+        console.error('[Gateway] SSE client closed')
+        if (!this.closing) {
+          this.cleanup().catch(err => {
+            console.error('[Gateway] Cleanup error during close:', err)
+          })
+        }
+      }
+  
+      process.on('SIGINT', () => this.cleanup())
+      process.on('SIGTERM', () => this.cleanup())
+    }
+  
+    private async cleanup(): Promise<void> {
+      if (this.closing) {
+        return
+      }
+  
+      this.closing = true
+      console.error('[Gateway] Starting cleanup...')
+  
+      try {
+        if (this.client) {
+          console.error('[Gateway] Closing SSE client...')
+          await this.client.close()
+        }
+  
+        if (this.server) {
+          console.error('[Gateway] Closing server...')
+          await this.server.close()
+        }
+  
+        console.error('[Gateway] Cleanup completed')
+        process.exit(0)
+      } catch (error) {
+        console.error('[Gateway] Fatal error during cleanup:', error)
+        process.exit(1)
+      }
+    }
+  
+    private async handleStdioConnection(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
+      // Find the STDIO connection details
+      const stdioConnection = serverDetails.connections.find(conn => conn.type === 'stdio')
+      if (!stdioConnection) {
+        throw new Error('No STDIO connection found')
+      }
+  
+      // Process config values using the connection's schema
+      const processedConfig = await collectConfigValues(stdioConnection, config)
+  
+      // Get the configured command from registry with processed config
+      const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverDetails.id}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          connectionType: 'stdio',
+          config: processedConfig
+        })
+      });
+  
+      if (!response.ok) {
+        throw new Error(`Failed to get server configuration: ${response.statusText}`);
+      }
+  
+      const { result } = await response.json();
+      const serverConfig = result as ConfiguredStdioServer;
+      
+      console.error('[Gateway] Server configuration:', serverConfig)
+  
+      console.error('[Gateway] Spawning local STDIO process:', {
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: Object.fromEntries(
+          Object.entries(serverConfig.env || {}).map(([key, value]) => 
+            [key, key.toLowerCase().includes('key') ? '****' : value]
+          )
+        )
+      })
+  
+      const { command, args, env } = serverConfig
+      
+      console.error('[Gateway] Spawning local STDIO process:', {
+        command,
+        args,
+        env: Object.fromEntries(
+          Object.entries(env || {}).map(([key, value]) => 
+            [key, key.toLowerCase().includes('key') ? '****' : value]
+          )
+        )
+      })
+  
+      const childProcess = spawn(command, args || [], {
+        ...serverConfig,
+        env: {
+          ...(Object.fromEntries(
+            Object.entries(process.env).filter(([_, v]) => v != null)
+          ) as Record<string, string>),
+          ...serverConfig.env
+        }
+      })
+  
+      console.error('[Gateway] Process spawned with:', {
+        command,
+        args,
+        env: Object.fromEntries(
+          Object.entries(env || {}).map(([key, value]) => 
+            [key, key.toLowerCase().includes('key') ? '****' : value]
+          )
+        )
+      })
+  
+      // Connect to the spawned process as a client
+      this.client = new Client(
+        { name: `smithery-runner-${serverDetails.id}`, version: '1.0.0' },
+        { capabilities: {} }
+      )
+      const processTransport = new StdioClientTransport({
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: {
+          ...(Object.fromEntries(
+            Object.entries(process.env).filter(([_, v]) => v != null)
+          ) as Record<string, string>),
+          ...serverConfig.env
+        }
+      })
+      await this.client.connect(processTransport)
+  
+      // Get capabilities from the spawned process
+      const capabilities = this.client.getServerCapabilities() || {}
+      console.error('[Gateway] Process server capabilities:', capabilities)
+  
+      // Create local STDIO server with same capabilities
+      this.server = new Server(
+        { name: `smithery-runner-${serverDetails.id}`, version: '1.0.0' },
+        { capabilities }
+      )
+  
+      // Set up error handling
+      this.setupErrorHandling()
+  
+      // Set up handlers to proxy between local server and spawned process
+      await this.setupHandlers(capabilities)
+  
+      // Connect local STDIO server to handle stdin/stdout
+      const stdioTransport = new StdioServerTransport()
+      await this.server.connect(stdioTransport)
+      console.error('[Gateway] STDIO proxy server ready')
+  
+      // Handle process exit
+      childProcess.on('error', (error) => {
+        console.error('[Gateway] Child process error:', error)
+        process.exit(1)
+      })
+  
+      childProcess.on('exit', (code, signal) => {
+        console.error('[Gateway] Child process exited:', { code, signal })
+        process.exit(code ?? 1)
+      })
+    }
+  
+    private async handleSSEConnection(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
+      // Get SSE connection
+      const sseConnection = serverDetails.connections.find(conn => conn.type === 'sse')
+      if (!sseConnection?.deploymentUrl) {
+        throw new Error('SSE connection missing deployment URL')
+      }
+  
+      // Add /sse to the deployment URL before creating the Smithery URL
+      const sseUrl = new URL('/sse', sseConnection.deploymentUrl).toString()
+      const connectionUrl = createSmitheryUrl(
+        sseUrl,
+        config || {}
+      )
+  
+      console.error('[Gateway] Attempting to connect to SSE server at:', connectionUrl)
+  
+      try {
+        // Connect SSE client first to discover capabilities
+        const sseTransport = new SSEClientTransport(new URL(connectionUrl))
+        await this.client.connect(sseTransport)
+        console.error('[Gateway] Connected to remote SSE server')
+      } catch (sseError) {
+        console.error('[Gateway] Failed to connect to SSE server:', {
+          url: connectionUrl,
+          error: sseError,
+          status: (sseError as any)?.status,
+          message: (sseError as any)?.message
+        })
+        throw sseError
+      }
+  
+      // Get capabilities
+      const capabilities = this.client.getServerCapabilities() || {}
+      console.error('[Gateway] Remote server capabilities:', capabilities)
+  
+      // Create server with the discovered capabilities
+      this.server = new Server(
+        { name: `smithery-runner-${serverDetails.id}`, version: '1.0.0' },
+        { capabilities }
+      )
+  
+      // Set up error handling
+      this.setupErrorHandling()
+  
+      // Set up handlers based on remote capabilities
+      await this.setupHandlers(capabilities)
+  
+      // Finally connect local STDIO server
+      const stdioTransport = new StdioServerTransport()
+      await this.server.connect(stdioTransport)
+      console.error('[Gateway] STDIO server ready')
+    }
+  
+    async run(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
+      try {
+        // Check connection types available
+        const hasSSE = serverDetails.connections.some(conn => conn.type === 'sse')
+        const hasStdio = serverDetails.connections.some(conn => conn.type === 'stdio')
+  
+        if (hasSSE) {
+          // Handle SSE connection (remote server)
+          await this.handleSSEConnection(serverDetails, config)
+        } else if (hasStdio) {
+          // Handle STDIO-only connection
+          await this.handleStdioConnection(serverDetails, config)
+        } else {
+          throw new Error('No valid connection types found')
+        }
+  
+      } catch (error) {
+        console.error('[Gateway] Setup error:', error)
+        await this.cleanup()
+        throw error
+      }
+    }
+  }

--- a/src/services/gateway-server.ts
+++ b/src/services/gateway-server.ts
@@ -1,322 +1,359 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
-import { ClientRequest, ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
-import { z } from 'zod'
-import { HandlerManager } from '../utils/mcp-handlers.js'
-import { ResolvedServer, ConfiguredStdioServer } from '../types/registry.js'
-import { spawn, ChildProcessWithoutNullStreams } from 'child_process'
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+import type {
+	ClientRequest,
+	ServerCapabilities,
+} from "@modelcontextprotocol/sdk/types.js"
+import type { z } from "zod"
+import { HandlerManager } from "../utils/mcp-handlers.js"
+import type {
+	ResolvedServer,
+	ConfiguredStdioServer,
+} from "../types/registry.js"
 import { createSmitheryUrl } from "@smithery/sdk/config.js"
-import { collectConfigValues } from '../utils/runtime-utils.js'
-import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { collectConfigValues } from "../utils/runtime-utils.js"
+import {
+	StdioClientTransport,
+	getDefaultEnvironment,
+} from "@modelcontextprotocol/sdk/client/stdio.js"
 import { REGISTRY_ENDPOINT } from "../constants.js"
-import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol.js'
+import { DEFAULT_REQUEST_TIMEOUT_MSEC } from "@modelcontextprotocol/sdk/shared/protocol.js"
 
 export class GatewayServer {
-    private server!: Server
-    private client: Client
-    private handlerManager!: HandlerManager
-    private closing = false
-    private requestTimeout = DEFAULT_REQUEST_TIMEOUT_MSEC
-    
-    constructor() {
-      this.closing = false
-      
-      this.client = new Client(
-        { name: 'smithery-runner', version: '1.0.0' },
-        { capabilities: {} }
-      )
-    }
-  
-    private async makeRequest<T extends z.ZodType>(request: ClientRequest, schema: T) {
-      if (!this.client) {
-        throw new Error("Client not connected");
-      }
-  
-      const abortController = new AbortController();
-      const timeoutId = setTimeout(() => {
-        abortController.abort("Request timed out");
-      }, this.requestTimeout);
-  
-      try {
-        const response = await this.client.request(request, schema, {
-          signal: abortController.signal,
-        });
-        return response;
-      } finally {
-        clearTimeout(timeoutId);
-      }
-    }
-  
-    private async setupHandlers(Capabilities: ServerCapabilities): Promise<void> {
-      this.handlerManager = new HandlerManager(
-        this.server,
-        this.makeRequest.bind(this)
-      )
-      await this.handlerManager.setupHandlers(Capabilities)
-    }
-  
-    private setupErrorHandling(): void {
-      this.server.onerror = (error) => {
-        console.error('[Gateway] Server error:', error)
-        if (!this.closing) {
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during error handling:', err)
-          })
-        }
-      }
-  
-      this.client.onerror = (error) => {
-        console.error('[Gateway] SSE client error:', error)
-        if (!this.closing) {
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during error handling:', err)
-          })
-        }
-      }
-  
-      this.server.onclose = () => {
-        console.error('[Gateway] Server closed')
-        if (!this.closing) {
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during close:', err)
-          })
-        }
-      }
-  
-      this.client.onclose = () => {
-        console.error('[Gateway] SSE client closed')
-        if (!this.closing) {
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during close:', err)
-          })
-        }
-      }
-  
-      process.on('SIGINT', () => this.cleanup())
-      process.on('SIGTERM', () => this.cleanup())
-    }
-  
-    private async cleanup(): Promise<void> {
-      if (this.closing) {
-        return
-      }
-  
-      this.closing = true
-      console.error('[Gateway] Starting cleanup...')
-  
-      try {
-        if (this.client) {
-          console.error('[Gateway] Closing SSE client...')
-          await this.client.close()
-        }
-  
-        if (this.server) {
-          console.error('[Gateway] Closing server...')
-          await this.server.close()
-        }
-  
-        console.error('[Gateway] Cleanup completed')
-        process.exit(0)
-      } catch (error) {
-        console.error('[Gateway] Fatal error during cleanup:', error)
-        process.exit(1)
-      }
-    }
-  
-    private async handleStdioConnection(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
-      // Find the STDIO connection details
-      const stdioConnection = serverDetails.connections.find(conn => conn.type === 'stdio')
-      if (!stdioConnection) {
-        throw new Error('No STDIO connection found')
-      }
-  
-      // Process config values using the connection's schema
-      const processedConfig = await collectConfigValues(stdioConnection, config)
-  
-      // Get the configured command from registry with processed config
-      const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverDetails.id}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          connectionType: 'stdio',
-          config: processedConfig
-        })
-      });
-  
-      if (!response.ok) {
-        throw new Error(`Failed to get server configuration: ${response.statusText}`);
-      }
-  
-      const { result } = await response.json();
-      const serverConfig = result as ConfiguredStdioServer;
-      
-      console.error('[Gateway] Server configuration:', serverConfig)
-  
-      const { command, args, env } = serverConfig
-      let clientTransport: StdioClientTransport | null = null
+	private server!: Server
+	private client: Client
+	private handlerManager!: HandlerManager
+	private closing = false
+	private requestTimeout = DEFAULT_REQUEST_TIMEOUT_MSEC
 
-      try {
-        // Merge default environment with provided env
-        const defaultEnv = getDefaultEnvironment()
-        const mergedEnv = {
-          ...defaultEnv,
-          ...(env || {})
-        }
+	constructor() {
+		this.closing = false
 
-        // Create client transport
-        clientTransport = new StdioClientTransport({
-          command,
-          args: args || [],
-          env: mergedEnv,
-          stderr: 'pipe'
-        })
+		this.client = new Client(
+			{ name: "smithery-runner", version: "1.0.0" },
+			{ capabilities: {} },
+		)
+	}
 
-        // Set up transport error handling
-        clientTransport.onerror = (error) => {
-          console.error('[Gateway] STDIO transport error:', error)
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during transport error:', err)
-          })
-        }
+	private async makeRequest<T extends z.ZodType>(
+		request: ClientRequest,
+		schema: T,
+	) {
+		if (!this.client) {
+			throw new Error("Client not connected")
+		}
 
-        // Connect client to get capabilities
-        await this.client.connect(clientTransport)
-        
-        // Get capabilities from the client
-        const capabilities = this.client.getServerCapabilities() || {}
-        console.error('[Gateway] Child process capabilities:', capabilities)
+		const abortController = new AbortController()
+		const timeoutId = setTimeout(() => {
+			abortController.abort("Request timed out")
+		}, this.requestTimeout)
 
-        // Create server with the discovered capabilities
-        this.server = new Server(
-          { name: `smithery-runner-${serverDetails.id}`, version: '1.0.0' },
-          { capabilities }
-        )
+		try {
+			const response = await this.client.request(request, schema, {
+				signal: abortController.signal,
+			})
+			return response
+		} finally {
+			clearTimeout(timeoutId)
+		}
+	}
 
-        // Set up error handling
-        this.setupErrorHandling()
+	private async setupHandlers(Capabilities: ServerCapabilities): Promise<void> {
+		this.handlerManager = new HandlerManager(
+			this.server,
+			this.makeRequest.bind(this),
+		)
+		await this.handlerManager.setupHandlers(Capabilities)
+	}
 
-        // Set up handlers based on capabilities
-        await this.setupHandlers(capabilities)
+	private setupErrorHandling(): void {
+		this.server.onerror = (error) => {
+			console.error("[Gateway] Server error:", error)
+			if (!this.closing) {
+				this.cleanup().catch((err) => {
+					console.error("[Gateway] Cleanup error during error handling:", err)
+				})
+			}
+		}
 
-        // Create and connect server transport
-        const serverTransport = new StdioServerTransport()
-        await this.server.connect(serverTransport)
-        console.error('[Gateway] STDIO server ready')
+		this.client.onerror = (error) => {
+			console.error("[Gateway] SSE client error:", error)
+			if (!this.closing) {
+				this.cleanup().catch((err) => {
+					console.error("[Gateway] Cleanup error during error handling:", err)
+				})
+			}
+		}
 
-        // Handle stderr output
-        if (clientTransport.stderr) {
-          clientTransport.stderr.on('data', (chunk: Buffer) => {
-            console.error('[Gateway] Child process stderr:', chunk.toString())
-          })
-        }
+		this.server.onclose = () => {
+			console.error("[Gateway] Server closed")
+			if (!this.closing) {
+				this.cleanup().catch((err) => {
+					console.error("[Gateway] Cleanup error during close:", err)
+				})
+			}
+		}
 
-      } catch (error) {
-        console.error('[Gateway] Error during STDIO setup:', error)
-        
-        // Attempt to clean up the transport if it was created
-        if (clientTransport) {
-          try {
-            await clientTransport.close()
-          } catch (closeError) {
-            console.error('[Gateway] Error closing transport during error recovery:', closeError)
-          }
-        }
-        
-        throw error
-      }
+		this.client.onclose = () => {
+			console.error("[Gateway] SSE client closed")
+			if (!this.closing) {
+				this.cleanup().catch((err) => {
+					console.error("[Gateway] Cleanup error during close:", err)
+				})
+			}
+		}
 
-      // Add cleanup handler for process termination
-      const cleanupHandler = () => {
-        if (clientTransport && !this.closing) {
-          console.error('[Gateway] Process termination detected, cleaning up...')
-          this.cleanup().catch(err => {
-            console.error('[Gateway] Cleanup error during process termination:', err)
-            process.exit(1)
-          })
-        }
-      }
+		process.on("SIGINT", () => this.cleanup())
+		process.on("SIGTERM", () => this.cleanup())
+	}
 
-      process.once('SIGTERM', cleanupHandler)
-      process.once('SIGINT', cleanupHandler)
-    }
-  
-    private async handleSSEConnection(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
-      // Get SSE connection
-      const sseConnection = serverDetails.connections.find(conn => conn.type === 'sse')
-      if (!sseConnection?.deploymentUrl) {
-        throw new Error('SSE connection missing deployment URL')
-      }
-  
-      // Add /sse to the deployment URL before creating the Smithery URL
-      const sseUrl = new URL('/sse', sseConnection.deploymentUrl).toString()
-      const connectionUrl = createSmitheryUrl(
-        sseUrl,
-        config || {}
-      )
-  
-      console.error('[Gateway] Attempting to connect to SSE server at:', connectionUrl)
-  
-      try {
-        // Connect SSE client first to discover capabilities
-        const sseTransport = new SSEClientTransport(new URL(connectionUrl))
-        await this.client.connect(sseTransport)
-        console.error('[Gateway] Connected to remote SSE server')
-      } catch (sseError) {
-        console.error('[Gateway] Failed to connect to SSE server:', {
-          url: connectionUrl,
-          error: sseError,
-          status: (sseError as any)?.status,
-          message: (sseError as any)?.message
-        })
-        throw sseError
-      }
-  
-      // Get capabilities
-      const capabilities = this.client.getServerCapabilities() || {}
-      console.error('[Gateway] Remote server capabilities:', capabilities)
-  
-      // Create server with the discovered capabilities
-      this.server = new Server(
-        { name: `smithery-runner-${serverDetails.id}`, version: '1.0.0' },
-        { capabilities }
-      )
-  
-      // Set up error handling
-      this.setupErrorHandling()
-  
-      // Set up handlers based on remote capabilities
-      await this.setupHandlers(capabilities)
-  
-      // Finally connect local STDIO server
-      const stdioTransport = new StdioServerTransport()
-      await this.server.connect(stdioTransport)
-      console.error('[Gateway] STDIO server ready')
-    }
-  
-    async run(serverDetails: ResolvedServer, config: Record<string, unknown>): Promise<void> {
-      try {
-        // Check connection types available
-        const hasSSE = serverDetails.connections.some(conn => conn.type === 'sse')
-        const hasStdio = serverDetails.connections.some(conn => conn.type === 'stdio')
-  
-        if (hasSSE) {
-          // Handle SSE connection (remote server)
-          await this.handleSSEConnection(serverDetails, config)
-        } else if (hasStdio) {
-          // Handle STDIO-only connection
-          await this.handleStdioConnection(serverDetails, config)
-        } else {
-          throw new Error('No valid connection types found')
-        }
-  
-      } catch (error) {
-        console.error('[Gateway] Setup error:', error)
-        await this.cleanup()
-        throw error
-      }
-    }
-  }
+	private async cleanup(): Promise<void> {
+		if (this.closing) {
+			return
+		}
+
+		this.closing = true
+		console.error("[Gateway] Starting cleanup...")
+
+		try {
+			if (this.client) {
+				console.error("[Gateway] Closing SSE client...")
+				await this.client.close()
+			}
+
+			if (this.server) {
+				console.error("[Gateway] Closing server...")
+				await this.server.close()
+			}
+
+			console.error("[Gateway] Cleanup completed")
+			process.exit(0)
+		} catch (error) {
+			console.error("[Gateway] Fatal error during cleanup:", error)
+			process.exit(1)
+		}
+	}
+
+	private async handleStdioConnection(
+		serverDetails: ResolvedServer,
+		config: Record<string, unknown>,
+	): Promise<void> {
+		// Find the STDIO connection details
+		const stdioConnection = serverDetails.connections.find(
+			(conn) => conn.type === "stdio",
+		)
+		if (!stdioConnection) {
+			throw new Error("No STDIO connection found")
+		}
+
+		// Process config values using the connection's schema
+		const processedConfig = await collectConfigValues(stdioConnection, config)
+
+		// Get the configured command from registry with processed config
+		const response = await fetch(
+			`${REGISTRY_ENDPOINT}/servers/${serverDetails.id}`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					connectionType: "stdio",
+					config: processedConfig,
+				}),
+			},
+		)
+
+		if (!response.ok) {
+			throw new Error(
+				`Failed to get server configuration: ${response.statusText}`,
+			)
+		}
+
+		const { result } = await response.json()
+		const serverConfig = result as ConfiguredStdioServer
+
+		console.error("[Gateway] Server configuration:", serverConfig)
+
+		const { command, args, env } = serverConfig
+		let clientTransport: StdioClientTransport | null = null
+
+		try {
+			// Merge default environment with provided env
+			const defaultEnv = getDefaultEnvironment()
+			const mergedEnv = {
+				...defaultEnv,
+				...(env || {}),
+			}
+
+			// Create client transport
+			clientTransport = new StdioClientTransport({
+				command,
+				args: args || [],
+				env: mergedEnv,
+				stderr: "pipe",
+			})
+
+			// Set up transport error handling
+			clientTransport.onerror = (error) => {
+				console.error("[Gateway] STDIO transport error:", error)
+				this.cleanup().catch((err) => {
+					console.error("[Gateway] Cleanup error during transport error:", err)
+				})
+			}
+
+			// Connect client to get capabilities
+			await this.client.connect(clientTransport)
+
+			// Get capabilities from the client
+			const capabilities = this.client.getServerCapabilities() || {}
+			console.error("[Gateway] Child process capabilities:", capabilities)
+
+			// Create server with the discovered capabilities
+			this.server = new Server(
+				{ name: `smithery-runner-${serverDetails.id}`, version: "1.0.0" },
+				{ capabilities },
+			)
+
+			// Set up error handling
+			this.setupErrorHandling()
+
+			// Set up handlers based on capabilities
+			await this.setupHandlers(capabilities)
+
+			// Create and connect server transport
+			const serverTransport = new StdioServerTransport()
+			await this.server.connect(serverTransport)
+			console.error("[Gateway] STDIO server ready")
+
+			// Handle stderr output
+			if (clientTransport.stderr) {
+				clientTransport.stderr.on("data", (chunk: Buffer) => {
+					console.error("[Gateway] Child process stderr:", chunk.toString())
+				})
+			}
+		} catch (error) {
+			console.error("[Gateway] Error during STDIO setup:", error)
+
+			// Attempt to clean up the transport if it was created
+			if (clientTransport) {
+				try {
+					await clientTransport.close()
+				} catch (closeError) {
+					console.error(
+						"[Gateway] Error closing transport during error recovery:",
+						closeError,
+					)
+				}
+			}
+
+			throw error
+		}
+
+		// Add cleanup handler for process termination
+		const cleanupHandler = () => {
+			if (clientTransport && !this.closing) {
+				console.error("[Gateway] Process termination detected, cleaning up...")
+				this.cleanup().catch((err) => {
+					console.error(
+						"[Gateway] Cleanup error during process termination:",
+						err,
+					)
+					process.exit(1)
+				})
+			}
+		}
+
+		process.once("SIGTERM", cleanupHandler)
+		process.once("SIGINT", cleanupHandler)
+	}
+
+	private async handleSSEConnection(
+		serverDetails: ResolvedServer,
+		config: Record<string, unknown>,
+	): Promise<void> {
+		// Get SSE connection
+		const sseConnection = serverDetails.connections.find(
+			(conn) => conn.type === "sse",
+		)
+		if (!sseConnection?.deploymentUrl) {
+			throw new Error("SSE connection missing deployment URL")
+		}
+
+		// Add /sse to the deployment URL before creating the Smithery URL
+		const sseUrl = new URL("/sse", sseConnection.deploymentUrl).toString()
+		const connectionUrl = createSmitheryUrl(sseUrl, config || {})
+
+		console.error(
+			"[Gateway] Attempting to connect to SSE server at:",
+			connectionUrl,
+		)
+
+		try {
+			// Connect SSE client first to discover capabilities
+			const sseTransport = new SSEClientTransport(new URL(connectionUrl))
+			await this.client.connect(sseTransport)
+			console.error("[Gateway] Connected to remote SSE server")
+		} catch (sseError) {
+			console.error("[Gateway] Failed to connect to SSE server:", {
+				url: connectionUrl,
+				error: sseError,
+				status: (sseError as any)?.status,
+				message: (sseError as any)?.message,
+			})
+			throw sseError
+		}
+
+		// Get capabilities
+		const capabilities = this.client.getServerCapabilities() || {}
+		console.error("[Gateway] Remote server capabilities:", capabilities)
+
+		// Create server with the discovered capabilities
+		this.server = new Server(
+			{ name: `smithery-runner-${serverDetails.id}`, version: "1.0.0" },
+			{ capabilities },
+		)
+
+		// Set up error handling
+		this.setupErrorHandling()
+
+		// Set up handlers based on remote capabilities
+		await this.setupHandlers(capabilities)
+
+		// Finally connect local STDIO server
+		const stdioTransport = new StdioServerTransport()
+		await this.server.connect(stdioTransport)
+		console.error("[Gateway] STDIO server ready")
+	}
+
+	async run(
+		serverDetails: ResolvedServer,
+		config: Record<string, unknown>,
+	): Promise<void> {
+		try {
+			// Check connection types available
+			const hasSSE = serverDetails.connections.some(
+				(conn) => conn.type === "sse",
+			)
+			const hasStdio = serverDetails.connections.some(
+				(conn) => conn.type === "stdio",
+			)
+
+			if (hasSSE) {
+				// Handle SSE connection (remote server)
+				await this.handleSSEConnection(serverDetails, config)
+			} else if (hasStdio) {
+				// Handle STDIO-only connection
+				await this.handleStdioConnection(serverDetails, config)
+			} else {
+				throw new Error("No connection types found. Server not deployed.")
+			}
+		} catch (error) {
+			console.error("[Gateway] Setup error:", error)
+			await this.cleanup()
+			throw error
+		}
+	}
+}

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -23,11 +23,22 @@ export const JSONSchemaSchema: z.ZodType = z.lazy(() =>
 
 export type JSONSchema = z.infer<typeof JSONSchemaSchema>
 
-export const ConnectionDetailsSchema = z.object({
-	type: z.enum(["stdio"]),
-	configSchema: JSONSchemaSchema.optional(),
-	exampleConfig: z.record(z.any()).optional(),
-})
+// Update ConnectionDetailsSchema to handle both STDIO and SSE
+export const ConnectionDetailsSchema = z.union([
+	z.object({
+		type: z.literal("stdio"),
+		configSchema: JSONSchemaSchema.optional(),
+		exampleConfig: z.record(z.any()).optional(),
+		published: z.boolean().optional(),
+		stdioFunction: z.string().optional(),
+	}),
+	z.object({
+		type: z.literal("sse"),
+		deploymentUrl: z.string().url(),
+		configSchema: JSONSchemaSchema.optional(),
+		exampleConfig: z.record(z.any()).optional(),
+	}),
+])
 
 export type ConnectionDetails = z.infer<typeof ConnectionDetailsSchema>
 
@@ -60,5 +71,14 @@ export const StdioConnectionSchema = z.object({
 
 export type StdioConnection = z.infer<typeof StdioConnectionSchema>
 
-// used in POST request and also in local fetch from config file
-export type ConfiguredServer = StdioConnection
+// Add SSE connection type
+export const SSEConnectionSchema = z.object({
+	type: z.literal("sse"),
+	url: z.string().url(),
+	config: z.record(z.any()).optional(),
+})
+
+export type SSEConnection = z.infer<typeof SSEConnectionSchema>
+
+// Update ConfiguredServer to handle both types
+export type ConfiguredServer = StdioConnection | SSEConnection

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -82,3 +82,4 @@ export type SSEConnection = z.infer<typeof SSEConnectionSchema>
 
 // Update ConfiguredServer to handle both types
 export type ConfiguredServer = StdioConnection | SSEConnection
+export type ConfiguredStdioServer = StdioConnection

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import type { MCPConfig, StdioConnection, ConfiguredServer } from "../types/registry.js"
+import type { MCPConfig, ConfiguredServer } from "../types/registry.js"
 
 export interface ClaudeConfig extends MCPConfig {
 	[key: string]: any

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import type { MCPConfig, StdioConnection } from "../types/registry.js"
+import type { MCPConfig, StdioConnection, ConfiguredServer } from "../types/registry.js"
 
 export interface ClaudeConfig extends MCPConfig {
 	[key: string]: any
@@ -109,7 +109,7 @@ export class ConfigManager {
 
 	static async installServer(
 		id: string,
-		serverConfig: StdioConnection,
+		serverConfig: ConfiguredServer,
 		client: string,
 	): Promise<void> {
 		const normalizedId = ConfigManager.normalizeServerId(id)
@@ -129,7 +129,7 @@ export class ConfigManager {
 		ConfigManager.writeConfig(config, client)
 	}
 
-	static getServerConfig(id: string, client: string): StdioConnection | null {
+	static getServerConfig(id: string, client: string): ConfiguredServer | null {
 		const config = ConfigManager.readConfig(client)
 		return config.mcpServers[id] || null
 	}

--- a/src/utils/mcp-handlers.ts
+++ b/src/utils/mcp-handlers.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+  ListToolsResultSchema,
+  CompatibilityCallToolResultSchema,
+  ListResourcesResultSchema,
+  ReadResourceResultSchema,
+  McpError,
+  ErrorCode,
+  ListResourceTemplatesResultSchema,
+  ListPromptsResultSchema,
+  GetPromptResultSchema,
+  ServerCapabilities,
+  ClientRequest
+} from '@modelcontextprotocol/sdk/types.js'
+
+export class HandlerManager {
+  constructor(
+    private server: Server,
+    private sseClient: Client,
+    private makeRequest: <T extends z.ZodType>(request: ClientRequest, schema: T) => Promise<z.infer<T>>
+  ) {}
+
+  async setupHandlers(remoteCapabilities: ServerCapabilities): Promise<void> {
+    console.error('[Gateway] Setting up handlers for remote capabilities:', remoteCapabilities)
+    
+    if (remoteCapabilities.tools) {
+      this.setupToolHandlers()
+    }
+    if (remoteCapabilities.resources) {
+      this.setupResourceHandlers()
+    }
+    if (remoteCapabilities.prompts) {
+      this.setupPromptHandlers()
+    }
+
+    console.error('[Gateway] Handlers setup complete')
+  }
+
+  private setupToolHandlers(): void {
+    this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+      console.error('[Gateway] ListTools request:', JSON.stringify(request, null, 2))
+      const response = await this.makeRequest(
+        { method: "tools/list" as const, params: {} },
+        ListToolsResultSchema
+      );
+      return response;
+    })
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      console.error('[Gateway] CallTool request:', JSON.stringify(request, null, 2))
+      try {
+        const response = await this.makeRequest(
+          {
+            method: "tools/call" as const,
+            params: request.params
+          },
+          CompatibilityCallToolResultSchema
+        );
+        console.error('[Gateway] CallTool response:', JSON.stringify(response, null, 2))
+        return response;
+      } catch (error) {
+        console.error('[Gateway] CallTool error:', error);
+        throw error;
+      }
+    })
+  }
+
+  private setupResourceHandlers(): void {
+    this.server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
+      console.error('[Gateway] ListResources request:', JSON.stringify(request, null, 2))
+      const response = await this.makeRequest(
+        { method: "resources/list" as const, params: {} },
+        ListResourcesResultSchema
+      );
+      return response;
+    })
+
+    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      console.error('[Gateway] ReadResource request:', JSON.stringify(request, null, 2))
+      try {
+        const response = await this.makeRequest(
+          {
+            method: "resources/read" as const,
+            params: request.params
+          },
+          ReadResourceResultSchema
+        );
+        return response;
+      } catch (error) {
+        console.error('[Gateway] ReadResource error:', error);
+        throw error;
+      }
+    })
+
+    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
+      console.error('[Gateway] ListResourceTemplates request:', JSON.stringify(request, null, 2))
+      const response = await this.makeRequest(
+        { method: "resources/templates/list" as const, params: {} },
+        ListResourceTemplatesResultSchema
+      );
+      return response;
+    })
+  }
+
+  private setupPromptHandlers(): void {
+    this.server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+      console.error('[Gateway] ListPrompts request:', JSON.stringify(request, null, 2))
+      const response = await this.makeRequest(
+        { method: "prompts/list" as const, params: {} },
+        ListPromptsResultSchema
+      );
+      return response;
+    })
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      console.error('[Gateway] GetPrompt request:', JSON.stringify(request, null, 2))
+      try {
+        const response = await this.makeRequest(
+          {
+            method: "prompts/get" as const,
+            params: request.params
+          },
+          GetPromptResultSchema
+        );
+        return response;
+      } catch (error) {
+        console.error('[Gateway] GetPrompt error:', error);
+        throw error;
+      }
+    })
+  }
+} 

--- a/src/utils/mcp-handlers.ts
+++ b/src/utils/mcp-handlers.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
@@ -25,20 +24,19 @@ import {
 export class HandlerManager {
   constructor(
     private server: Server,
-    private sseClient: Client,
     private makeRequest: <T extends z.ZodType>(request: ClientRequest, schema: T) => Promise<z.infer<T>>
   ) {}
 
-  async setupHandlers(remoteCapabilities: ServerCapabilities): Promise<void> {
-    console.error('[Gateway] Setting up handlers for remote capabilities:', remoteCapabilities)
+  async setupHandlers(Capabilities: ServerCapabilities): Promise<void> {
+    console.error('[Gateway] Setting up handlers for remote capabilities:', Capabilities)
     
-    if (remoteCapabilities.tools) {
+    if (Capabilities.tools) {
       this.setupToolHandlers()
     }
-    if (remoteCapabilities.resources) {
+    if (Capabilities.resources) {
       this.setupResourceHandlers()
     }
-    if (remoteCapabilities.prompts) {
+    if (Capabilities.prompts) {
       this.setupPromptHandlers()
     }
 

--- a/src/utils/mcp-handlers.ts
+++ b/src/utils/mcp-handlers.ts
@@ -1,139 +1,176 @@
-import { z } from 'zod'
-import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import type { z } from "zod"
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
-  ListToolsResultSchema,
-  CompatibilityCallToolResultSchema,
-  ListResourcesResultSchema,
-  ReadResourceResultSchema,
-  McpError,
-  ErrorCode,
-  ListResourceTemplatesResultSchema,
-  ListPromptsResultSchema,
-  GetPromptResultSchema,
-  ServerCapabilities,
-  ClientRequest
-} from '@modelcontextprotocol/sdk/types.js'
+	ListToolsRequestSchema,
+	CallToolRequestSchema,
+	ListResourcesRequestSchema,
+	ReadResourceRequestSchema,
+	ListResourceTemplatesRequestSchema,
+	ListPromptsRequestSchema,
+	GetPromptRequestSchema,
+	ListToolsResultSchema,
+	CompatibilityCallToolResultSchema,
+	ListResourcesResultSchema,
+	ReadResourceResultSchema,
+	ListResourceTemplatesResultSchema,
+	ListPromptsResultSchema,
+	GetPromptResultSchema,
+	type ServerCapabilities,
+	type ClientRequest,
+} from "@modelcontextprotocol/sdk/types.js"
 
 export class HandlerManager {
-  constructor(
-    private server: Server,
-    private makeRequest: <T extends z.ZodType>(request: ClientRequest, schema: T) => Promise<z.infer<T>>
-  ) {}
+	constructor(
+		private server: Server,
+		private makeRequest: <T extends z.ZodType>(
+			request: ClientRequest,
+			schema: T,
+		) => Promise<z.infer<T>>,
+	) {}
 
-  async setupHandlers(Capabilities: ServerCapabilities): Promise<void> {
-    console.error('[Gateway] Setting up handlers for remote capabilities:', Capabilities)
-    
-    if (Capabilities.tools) {
-      this.setupToolHandlers()
-    }
-    if (Capabilities.resources) {
-      this.setupResourceHandlers()
-    }
-    if (Capabilities.prompts) {
-      this.setupPromptHandlers()
-    }
+	async setupHandlers(Capabilities: ServerCapabilities): Promise<void> {
+		console.error(
+			"[Gateway] Setting up handlers for remote capabilities:",
+			Capabilities,
+		)
 
-    console.error('[Gateway] Handlers setup complete')
-  }
+		if (Capabilities.tools) {
+			this.setupToolHandlers()
+		}
+		if (Capabilities.resources) {
+			this.setupResourceHandlers()
+		}
+		if (Capabilities.prompts) {
+			this.setupPromptHandlers()
+		}
 
-  private setupToolHandlers(): void {
-    this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-      console.error('[Gateway] ListTools request:', JSON.stringify(request, null, 2))
-      const response = await this.makeRequest(
-        { method: "tools/list" as const, params: {} },
-        ListToolsResultSchema
-      );
-      return response;
-    })
+		console.error("[Gateway] Handlers setup complete")
+	}
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      console.error('[Gateway] CallTool request:', JSON.stringify(request, null, 2))
-      try {
-        const response = await this.makeRequest(
-          {
-            method: "tools/call" as const,
-            params: request.params
-          },
-          CompatibilityCallToolResultSchema
-        );
-        console.error('[Gateway] CallTool response:', JSON.stringify(response, null, 2))
-        return response;
-      } catch (error) {
-        console.error('[Gateway] CallTool error:', error);
-        throw error;
-      }
-    })
-  }
+	private setupToolHandlers(): void {
+		this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+			console.error(
+				"[Gateway] ListTools request:",
+				JSON.stringify(request, null, 2),
+			)
+			const response = await this.makeRequest(
+				{ method: "tools/list" as const, params: {} },
+				ListToolsResultSchema,
+			)
+			return response
+		})
 
-  private setupResourceHandlers(): void {
-    this.server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
-      console.error('[Gateway] ListResources request:', JSON.stringify(request, null, 2))
-      const response = await this.makeRequest(
-        { method: "resources/list" as const, params: {} },
-        ListResourcesResultSchema
-      );
-      return response;
-    })
+		this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+			console.error(
+				"[Gateway] CallTool request:",
+				JSON.stringify(request, null, 2),
+			)
+			try {
+				const response = await this.makeRequest(
+					{
+						method: "tools/call" as const,
+						params: request.params,
+					},
+					CompatibilityCallToolResultSchema,
+				)
+				console.error(
+					"[Gateway] CallTool response:",
+					JSON.stringify(response, null, 2),
+				)
+				return response
+			} catch (error) {
+				console.error("[Gateway] CallTool error:", error)
+				throw error
+			}
+		})
+	}
 
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-      console.error('[Gateway] ReadResource request:', JSON.stringify(request, null, 2))
-      try {
-        const response = await this.makeRequest(
-          {
-            method: "resources/read" as const,
-            params: request.params
-          },
-          ReadResourceResultSchema
-        );
-        return response;
-      } catch (error) {
-        console.error('[Gateway] ReadResource error:', error);
-        throw error;
-      }
-    })
+	private setupResourceHandlers(): void {
+		this.server.setRequestHandler(
+			ListResourcesRequestSchema,
+			async (request) => {
+				console.error(
+					"[Gateway] ListResources request:",
+					JSON.stringify(request, null, 2),
+				)
+				const response = await this.makeRequest(
+					{ method: "resources/list" as const, params: {} },
+					ListResourcesResultSchema,
+				)
+				return response
+			},
+		)
 
-    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
-      console.error('[Gateway] ListResourceTemplates request:', JSON.stringify(request, null, 2))
-      const response = await this.makeRequest(
-        { method: "resources/templates/list" as const, params: {} },
-        ListResourceTemplatesResultSchema
-      );
-      return response;
-    })
-  }
+		this.server.setRequestHandler(
+			ReadResourceRequestSchema,
+			async (request) => {
+				console.error(
+					"[Gateway] ReadResource request:",
+					JSON.stringify(request, null, 2),
+				)
+				try {
+					const response = await this.makeRequest(
+						{
+							method: "resources/read" as const,
+							params: request.params,
+						},
+						ReadResourceResultSchema,
+					)
+					return response
+				} catch (error) {
+					console.error("[Gateway] ReadResource error:", error)
+					throw error
+				}
+			},
+		)
 
-  private setupPromptHandlers(): void {
-    this.server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
-      console.error('[Gateway] ListPrompts request:', JSON.stringify(request, null, 2))
-      const response = await this.makeRequest(
-        { method: "prompts/list" as const, params: {} },
-        ListPromptsResultSchema
-      );
-      return response;
-    })
+		this.server.setRequestHandler(
+			ListResourceTemplatesRequestSchema,
+			async (request) => {
+				console.error(
+					"[Gateway] ListResourceTemplates request:",
+					JSON.stringify(request, null, 2),
+				)
+				const response = await this.makeRequest(
+					{ method: "resources/templates/list" as const, params: {} },
+					ListResourceTemplatesResultSchema,
+				)
+				return response
+			},
+		)
+	}
 
-    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-      console.error('[Gateway] GetPrompt request:', JSON.stringify(request, null, 2))
-      try {
-        const response = await this.makeRequest(
-          {
-            method: "prompts/get" as const,
-            params: request.params
-          },
-          GetPromptResultSchema
-        );
-        return response;
-      } catch (error) {
-        console.error('[Gateway] GetPrompt error:', error);
-        throw error;
-      }
-    })
-  }
-} 
+	private setupPromptHandlers(): void {
+		this.server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+			console.error(
+				"[Gateway] ListPrompts request:",
+				JSON.stringify(request, null, 2),
+			)
+			const response = await this.makeRequest(
+				{ method: "prompts/list" as const, params: {} },
+				ListPromptsResultSchema,
+			)
+			return response
+		})
+
+		this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+			console.error(
+				"[Gateway] GetPrompt request:",
+				JSON.stringify(request, null, 2),
+			)
+			try {
+				const response = await this.makeRequest(
+					{
+						method: "prompts/get" as const,
+						params: request.params,
+					},
+					GetPromptResultSchema,
+				)
+				return response
+			} catch (error) {
+				console.error("[Gateway] GetPrompt error:", error)
+				throw error
+			}
+		})
+	}
+}

--- a/src/utils/registry-utils.ts
+++ b/src/utils/registry-utils.ts
@@ -7,10 +7,8 @@ import type {
 } from "../types/registry.js"
 import { ConfigManager } from "./config-manager.js"
 import { JSONSchema } from "../types/registry.js"
+import { REGISTRY_ENDPOINT } from "../constants.js"
 dotenv.config()
-
-export const REGISTRY_ENDPOINT = "http://localhost:3000/registry"
-	// process.env.REGISTRY_ENDPOINT || "https://registry.smithery.ai"
 
 export async function fetchServers(
 	client: string,

--- a/src/utils/registry-utils.ts
+++ b/src/utils/registry-utils.ts
@@ -4,9 +4,9 @@ import type {
 	ConnectionDetails,
 	RegistryServer,
 	ResolvedServer,
-	StdioConnection,
 } from "../types/registry.js"
 import { ConfigManager } from "./config-manager.js"
+import { JSONSchema } from "../types/registry.js"
 dotenv.config()
 
 export const REGISTRY_ENDPOINT = "http://localhost:3000/registry"
@@ -37,20 +37,20 @@ export async function fetchServers(
 }
 
 interface SSEConfigResponse {
-	configSchema: any;  // We can type this more strictly if needed
+	configSchema: JSONSchema;
 }
 
 export async function resolveServer(
 	serverId: string,
-	client: string,
+	client: string = 'claude'
 ): Promise<ResolvedServer | null> {
 	try {
 		const isInstalled = ConfigManager.isServerInstalled(serverId, client)
 		const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverId}`)
-		console.log(`\nRegistry response for ${serverId}:`, response.status)
+		// console.log(`\nRegistry response for ${serverId}:`, response.status)
 
 		if (!response.ok) {
-			console.log(`Server not found in registry. Is installed: ${isInstalled}`)
+			// console.log(`Server not found in registry. Is installed: ${isInstalled}`)
 			if (isInstalled) {
 				return {
 					id: serverId,
@@ -64,31 +64,31 @@ export async function resolveServer(
 		}
 
 		const registryServer: RegistryServer = await response.json()
-		console.log('\nRegistry server details:', {
-			qualifiedName: registryServer.qualifiedName,
-			displayName: registryServer.displayName,
-			connectionTypes: registryServer.connections.map(c => c.type)
-		})
+		// console.log('\nRegistry server details:', {
+		// 	qualifiedName: registryServer.qualifiedName,
+		// 	displayName: registryServer.displayName,
+		// 	connectionTypes: registryServer.connections.map(c => c.type)
+		// })
 
 		// Process connections and normalize structure
 		const processedConnections = await Promise.all(
 			registryServer.connections.map(async (connection) => {
-				console.log(`\nProcessing connection type: ${connection.type}`)
+				// console.log(`\nProcessing connection type: ${connection.type}`)
 				
 				if (connection.type === "sse" && connection.deploymentUrl) {
-					console.log(`Fetching SSE config from: ${connection.deploymentUrl}`)
+					// console.log(`Fetching SSE config from: ${connection.deploymentUrl}`)
 					try {
 						const configResponse = await fetch(
 							`${connection.deploymentUrl}/.well-known/mcp/smithery.json`
 						)
-						console.log('SSE config response:', configResponse.status)
+						// console.log('SSE config response:', configResponse.status)
 						
 						if (configResponse.ok) {
 							const sseConfig: SSEConfigResponse = await configResponse.json()
-							console.log('SSE config schema received:', {
-								hasSchema: !!sseConfig.configSchema,
-								schemaProperties: Object.keys(sseConfig.configSchema?.properties || {})
-							})
+							// console.log('SSE config schema received:', {
+							// 	hasSchema: !!sseConfig.configSchema,
+							// 	schemaProperties: Object.keys(sseConfig.configSchema?.properties || {})
+							// })
 							
 							return {
 								type: "sse" as const,
@@ -98,14 +98,14 @@ export async function resolveServer(
 							}
 						}
 					} catch (error) {
-						console.warn(`Failed to fetch SSE config schema: ${error}`)
+						// console.warn(`Failed to fetch SSE config schema: ${error}`)
 					}
 				}
 				// STDIO connections already have the right structure
-				console.log('STDIO connection schema:', {
-					hasSchema: !!connection.configSchema,
-					schemaProperties: Object.keys(connection.configSchema?.properties || {})
-				})
+				// console.log('STDIO connection schema:', {
+				// 	hasSchema: !!connection.configSchema,
+				// 	schemaProperties: Object.keys(connection.configSchema?.properties || {})
+				// })
 				return connection
 			})
 		)
@@ -117,16 +117,16 @@ export async function resolveServer(
 			isInstalled,
 			client,
 		}
-		console.log('\nFinal resolved server:', {
-			id: result.id,
-			name: result.name,
-			connectionCount: result.connections.length,
-			connectionTypes: result.connections.map(c => c.type)
-		})
+		// console.log('\nFinal resolved server:', {
+		// 	id: result.id,
+		// 	name: result.name,
+		// 	connectionCount: result.connections.length,
+		// 	connectionTypes: result.connections.map(c => c.type)
+		// })
 
 		return result
 	} catch (error) {
-		console.error('Error resolving server:', error)
+		// console.error('Error resolving server:', error)
 		return null
 	}
 }
@@ -167,7 +167,7 @@ export async function getServerConfiguration(
 			throw new Error(`Invalid JSON response from registry: ${errorMessage}`)
 		}
 	} catch (error) {
-		console.error("Error getting server configuration:", error)
+		// console.error("Error getting server configuration:", error)
 		return null
 	}
 }
@@ -191,7 +191,7 @@ export async function getServerDeploymentUrl(serverId: string): Promise<string |
 
 		return data.deploymentUrl
 	} catch (error) {
-		console.error('Error checking server deployment:', error)
+		// console.error('Error checking server deployment:', error)
 		return null
 	}
 }

--- a/src/utils/registry-utils.ts
+++ b/src/utils/registry-utils.ts
@@ -6,7 +6,7 @@ import type {
 	ResolvedServer,
 } from "../types/registry.js"
 import { ConfigManager } from "./config-manager.js"
-import { JSONSchema } from "../types/registry.js"
+import type { JSONSchema } from "../types/registry.js"
 import { REGISTRY_ENDPOINT } from "../constants.js"
 dotenv.config()
 
@@ -35,17 +35,17 @@ export async function fetchServers(
 }
 
 interface SSEConfigResponse {
-	configSchema: JSONSchema;
+	configSchema: JSONSchema
 }
 
 export async function resolveServer(
 	serverId: string,
-	client: string = 'claude'
+	client = "claude",
 ): Promise<ResolvedServer | null> {
 	try {
 		const isInstalled = ConfigManager.isServerInstalled(serverId, client)
 		const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverId}`)
-		// console.log(`\nRegistry response for ${serverId}:`, response.status)
+		// console.error(`\nRegistry response for ${serverId}:`, response.status)
 
 		if (!response.ok) {
 			// console.log(`Server not found in registry. Is installed: ${isInstalled}`)
@@ -72,27 +72,27 @@ export async function resolveServer(
 		const processedConnections = await Promise.all(
 			registryServer.connections.map(async (connection) => {
 				// console.log(`\nProcessing connection type: ${connection.type}`)
-				
+
 				if (connection.type === "sse" && connection.deploymentUrl) {
 					// console.log(`Fetching SSE config from: ${connection.deploymentUrl}`)
 					try {
 						const configResponse = await fetch(
-							`${connection.deploymentUrl}/.well-known/mcp/smithery.json`
+							`${connection.deploymentUrl}/.well-known/mcp/smithery.json`,
 						)
 						// console.log('SSE config response:', configResponse.status)
-						
+
 						if (configResponse.ok) {
 							const sseConfig: SSEConfigResponse = await configResponse.json()
 							// console.log('SSE config schema received:', {
 							// 	hasSchema: !!sseConfig.configSchema,
 							// 	schemaProperties: Object.keys(sseConfig.configSchema?.properties || {})
 							// })
-							
+
 							return {
 								type: "sse" as const,
 								deploymentUrl: connection.deploymentUrl,
 								configSchema: sseConfig.configSchema,
-								exampleConfig: connection.exampleConfig
+								exampleConfig: connection.exampleConfig,
 							}
 						}
 					} catch (error) {
@@ -105,7 +105,7 @@ export async function resolveServer(
 				// 	schemaProperties: Object.keys(connection.configSchema?.properties || {})
 				// })
 				return connection
-			})
+			}),
 		)
 
 		const result = {
@@ -174,10 +174,14 @@ export async function getServerConfiguration(
  * Checks if a server has a deployed SSE endpoint
  * Returns the deployment URL if available, null otherwise
  */
-export async function getServerDeploymentUrl(serverId: string): Promise<string | null> {
+export async function getServerDeploymentUrl(
+	serverId: string,
+): Promise<string | null> {
 	try {
-		const response = await fetch(`${REGISTRY_ENDPOINT}/servers/${serverId}/deployment`)
-		
+		const response = await fetch(
+			`${REGISTRY_ENDPOINT}/servers/${serverId}/deployment`,
+		)
+
 		if (!response.ok) {
 			return null
 		}

--- a/src/utils/registry-utils.ts
+++ b/src/utils/registry-utils.ts
@@ -124,7 +124,7 @@ export async function resolveServer(
 
 		return result
 	} catch (error) {
-		// console.error('Error resolving server:', error)
+		console.error('Error resolving server:', error)
 		return null
 	}
 }

--- a/src/utils/runtime-utils.ts
+++ b/src/utils/runtime-utils.ts
@@ -63,6 +63,7 @@ export async function promptForUVInstall(
 
 export async function collectConfigValues(
 	connection: ConnectionDetails,
+	existingValues?: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
 	const promptsMap = new Map<string, PromptInfo & { type?: string }>()
 
@@ -75,7 +76,7 @@ export async function collectConfigValues(
 				const schemaProp = prop as {
 					description?: string
 					default?: unknown
-					type?: string // Add type from JSON Schema
+					type?: string
 				}
 				promptsMap.set(key, {
 					key,
@@ -129,7 +130,23 @@ export async function collectConfigValues(
 		}
 	}
 
-	// Iterate through each configuration prompt
+	// If we have existing values, process them according to schema
+	if (existingValues) {
+		for (const prompt of promptsMap.values()) {
+			const value = existingValues[prompt.key]
+			if (value !== undefined || prompt.default !== undefined) {
+				configValues[prompt.key] = convertValueToType(
+					value ?? prompt.default,
+					prompt.type,
+				)
+			} else if (prompt.required) {
+				throw new Error(`Missing required config value: ${prompt.key}`)
+			}
+		}
+		return configValues
+	}
+
+	// Original prompting logic for installation
 	for (const prompt of promptsMap.values()) {
 		// If env var exists and setting is optional, ask if user wants to reuse it
 		if (process.env[prompt.key] && !prompt.required) {

--- a/src/utils/runtime-utils.ts
+++ b/src/utils/runtime-utils.ts
@@ -63,7 +63,7 @@ export async function promptForUVInstall(
 
 export async function collectConfigValues(
 	connection: ConnectionDetails,
-	existingValues?: Record<string, unknown>
+	existingValues?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
 	const promptsMap = new Map<string, PromptInfo & { type?: string }>()
 

--- a/src/utils/server-manager.ts
+++ b/src/utils/server-manager.ts
@@ -14,16 +14,9 @@ export class ServerManager {
 		this.configManager = configManager
 	}
 
-<<<<<<< HEAD
-	private validateConnection(server: ResolvedServer): ConnectionDetails {
-		const connection = server.connections?.[0]
-		if (!connection) {
-			throw new Error("No connection configuration found or server has not been deployed.")
-=======
 	private selectPreferredConnection(server: ResolvedServer): ConnectionDetails {
 		if (!server.connections?.length) {
 			throw new Error("No connection configuration found")
->>>>>>> 5fd2f3b (WIP: support for smithery/cli run)
 		}
 		
 		// Prioritize SSE connection if it exists

--- a/src/utils/server-manager.ts
+++ b/src/utils/server-manager.ts
@@ -18,20 +18,20 @@ export class ServerManager {
 		if (!server.connections?.length) {
 			throw new Error("No connection configuration found")
 		}
-		
+
 		// Prioritize SSE connection if it exists
-		const sseConnection = server.connections.find(conn => conn.type === "sse")
+		const sseConnection = server.connections.find((conn) => conn.type === "sse")
 		if (sseConnection) {
 			return sseConnection
 		}
-		
+
 		// Fall back to first available connection
 		return server.connections[0]
 	}
 
 	private formatServerConfig(
 		serverId: string,
-		userConfig: Record<string, unknown>
+		userConfig: Record<string, unknown>,
 	): ConfiguredServer {
 		return {
 			command: "npx",
@@ -41,8 +41,8 @@ export class ServerManager {
 				"run",
 				serverId,
 				"--config",
-				JSON.stringify(userConfig)
-			]
+				JSON.stringify(userConfig),
+			],
 		}
 	}
 
@@ -52,7 +52,7 @@ export class ServerManager {
 	): Promise<void> {
 		const connection = this.selectPreferredConnection(server) // checks if it has any connections
 		const configValues = await collectConfigValues(connection) // config values collected from configschema
-		
+
 		// Update: Instead of getting config from registry POST, format it for run command
 		const serverConfig = this.formatServerConfig(server.id, configValues)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"module": "ES2020",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"strict": true,
 		"skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"types": ["node"]
+		"types": ["node"],
+		"noEmit": true
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
PR makes the following changes:
1. install command: sets new client configuration:

**old:**
```json
    "smithery-fetch": {
      "command": "npx",
      "args": [
        "-y",
        "@smithery-fetch"
      ]
    },
```

**new:**
```json
    "smithery-fetch": {
      "command": "npx",
      "args": [
        "-y",
        "@smithery/cli",
        "run",
        "smithery-fetch",
        "--config",
        "{}"
      ]
    }
```
2. When client executes run command, following happens:
- calls registry to get server details (e.g., available connections)
- if multiple connections, prioritises SSE connections

**- for SSE connection:**
1. uses config values to create SSE connection url
2. creates a client to communicate with remote SSE server
3. creates proxy STDIO server as gateway to communicate with remote server with client as passthrough

**- for STDIO connection:**
1. uses config to POST request and receive STDIO server configuration
2. spawns child process with configuration
3. creates a client to communicate with spawned STDIO server (in similar pattern for remote SSE)
4. creates proxy STDIO server as gateway to communicate with spawned child process with client as passthrough