### PR TITLE
Add analytics and inform user of remote server installation

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -2,6 +2,7 @@ import chalk from "chalk"
 import { ServerManager } from "../utils/server-manager.js"
 import { resolveServer } from "../utils/registry-utils.js"
 import { VALID_CLIENTS, type ValidClient } from "../constants.js"
+import { SmitherySettings } from "../utils/smithery-settings.js"
 
 const serverManager = new ServerManager()
 
@@ -9,6 +10,10 @@ export async function install(
 	serverId: string,
 	client: ValidClient,
 ): Promise<void> {
+	// Initialize settings
+	const settings = new SmitherySettings()
+	await settings.initialize()
+
 	// ensure client is valid
 	if (client && !VALID_CLIENTS.includes(client as ValidClient)) {
 		console.error(

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -3,6 +3,7 @@ import { ServerManager } from "../utils/server-manager.js"
 import { resolveServer } from "../utils/registry-utils.js"
 import { VALID_CLIENTS, type ValidClient } from "../constants.js"
 import { SmitherySettings } from "../utils/smithery-settings.js"
+import inquirer from "inquirer"
 
 const serverManager = new ServerManager()
 
@@ -13,6 +14,17 @@ export async function install(
 	// Initialize settings
 	const settings = new SmitherySettings()
 	await settings.initialize()
+
+	// Ask for analytics consent if it hasn't been set yet
+	if (settings.getAnalyticsConsent() === false) {
+		const { shouldEnableAnalytics } = await inquirer.prompt([{
+			type: 'confirm',
+			name: 'shouldEnableAnalytics',
+			message: 'Would you like to help improve Smithery by sending anonymous usage data?',
+			default: false
+		}])
+		await settings.setAnalyticsConsent(shouldEnableAnalytics)
+	}
 
 	// ensure client is valid
 	if (client && !VALID_CLIENTS.includes(client as ValidClient)) {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -17,13 +17,13 @@ export async function install(
 
 	// Ask for analytics consent if it hasn't been set yet
 	if (settings.getAnalyticsConsent() === false) {
-		const { shouldEnableAnalytics } = await inquirer.prompt([{
+		const { EnableAnalytics } = await inquirer.prompt([{
 			type: 'confirm',
-			name: 'shouldEnableAnalytics',
+			name: 'EnableAnalytics',
 			message: 'Would you like to help improve Smithery by sending anonymous usage data?',
 			default: false
 		}])
-		await settings.setAnalyticsConsent(shouldEnableAnalytics)
+		await settings.setAnalyticsConsent(EnableAnalytics)
 	}
 
 	// ensure client is valid

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -32,6 +32,13 @@ export async function install(
 		process.exit(1)
 	}
 
+	const hasRemoteSSE = server.connections.some(
+		conn => conn.type === 'sse' && 'deploymentUrl' in conn
+	)
+	if (hasRemoteSSE) {
+		console.log(chalk.blue("Installing remote SSE server..."))
+	}
+
 	// install server using the serverManager instance
 	await serverManager.installServer(server, client)
 	console.log(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -26,8 +26,8 @@ export async function run(serverId: string, config: Record<string, unknown>) {
 		})
 
 		const server = new GatewayServer()
-		// Pass userId separately from config, fallback to undefined if there's a filesystem error
-		const userId = settings.getUserId() ?? undefined
+		// Pass userId if analytics consent was given
+		const userId = settings.getAnalyticsConsent() ? settings.getUserId() : undefined
 		await server.run(resolvedServer, config, userId)
 	} catch (error) {
 		console.error("[Runner] Fatal error:", error)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,6 +2,7 @@
 import { EventSource } from "eventsource"
 import { GatewayServer } from "../services/gateway-server.js"
 import { resolveServer } from "../utils/registry-utils.js"
+import { SmitherySettings } from "../utils/smithery-settings.js"
 
 global.EventSource = EventSource as any
 
@@ -9,6 +10,10 @@ global.EventSource = EventSource as any
 // routes between STDIO and SSE based on available connection
 export async function run(serverId: string, config: Record<string, unknown>) {
 	try {
+		// Initialize settings to get anonymous user ID
+		const settings = new SmitherySettings()
+		await settings.initialize()
+
 		// Look up server details from registry
 		const resolvedServer = await resolveServer(serverId)
 		if (!resolvedServer) {
@@ -21,7 +26,9 @@ export async function run(serverId: string, config: Record<string, unknown>) {
 		})
 
 		const server = new GatewayServer()
-		await server.run(resolvedServer, config)
+		// Pass userId separately from config, fallback to undefined if there's a filesystem error
+		const userId = settings.getUserId() ?? undefined
+		await server.run(resolvedServer, config, userId)
 	} catch (error) {
 		console.error("[Runner] Fatal error:", error)
 		process.exit(1)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,7 +10,7 @@ global.EventSource = EventSource as any
 // routes between STDIO and SSE based on available connection
 export async function run(serverId: string, config: Record<string, unknown>) {
 	try {
-		// Initialize settings to get anonymous user ID
+		// Initialize settings
 		const settings = new SmitherySettings()
 		await settings.initialize()
 

--- a/src/services/gateway-server.ts
+++ b/src/services/gateway-server.ts
@@ -158,6 +158,7 @@ export class GatewayServer {
 	private async handleStdioConnection(
 		serverDetails: ResolvedServer,
 		config: Record<string, unknown>,
+		userId?: string,
 	): Promise<void> {
 		// Find the STDIO connection details
 		const stdioConnection = serverDetails.connections.find(
@@ -181,6 +182,7 @@ export class GatewayServer {
 				body: JSON.stringify({
 					connectionType: "stdio",
 					config: processedConfig,
+					userId,
 				}),
 			},
 		)
@@ -402,9 +404,9 @@ export class GatewayServer {
 	async run(
 		serverDetails: ResolvedServer,
 		config: Record<string, unknown>,
+		userId?: string,
 	): Promise<void> {
 		try {
-			// Check connection types available
 			const hasSSE = serverDetails.connections.some(
 				(conn) => conn.type === "sse",
 			)
@@ -413,11 +415,9 @@ export class GatewayServer {
 			)
 
 			if (hasSSE) {
-				// Handle SSE connection (remote server)
 				await this.handleSSEConnection(serverDetails, config)
 			} else if (hasStdio) {
-				// Handle STDIO-only connection
-				await this.handleStdioConnection(serverDetails, config)
+				await this.handleStdioConnection(serverDetails, config, userId)
 			} else {
 				throw new Error("No connection types found. Server not deployed.")
 			}

--- a/src/utils/smithery-settings.ts
+++ b/src/utils/smithery-settings.ts
@@ -1,0 +1,71 @@
+import { homedir, platform } from 'os'
+import { join } from 'path'
+import { promises as fs } from 'fs'
+import { v4 as uuidv4 } from 'uuid'
+
+interface Settings {
+  userId: string;
+  cache?: {
+    servers?: Record<string, {
+      lastFetched: number;
+      data: unknown;
+    }>;
+  };
+}
+
+export class SmitherySettings {
+  private static getSettingsPath(): string {
+    switch (platform()) {
+      case 'win32':
+        return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'smithery');
+      case 'darwin':
+        return join(homedir(), 'Library', 'Application Support', 'smithery');
+      default:
+        return join(homedir(), '.config', 'smithery');
+    }
+  }
+
+  private static SETTINGS_PATH = join(SmitherySettings.getSettingsPath(), 'settings.json');
+  private data: Settings | null = null;
+
+  async initialize(): Promise<void> {
+    try {
+      await fs.mkdir(SmitherySettings.getSettingsPath(), { recursive: true });
+      
+      try {
+        const content = await fs.readFile(SmitherySettings.SETTINGS_PATH, 'utf-8');
+        this.data = JSON.parse(content);
+        
+        // Ensure userId exists in loaded data
+        if (this.data && !this.data.userId) {
+          this.data.userId = uuidv4();
+          await this.save();
+        }
+      } catch (error) {
+        // Create new settings if file doesn't exist
+        this.data = {
+          userId: uuidv4(),
+          cache: { servers: {} }
+        };
+        await this.save();
+      }
+    } catch (error) {
+      console.error('Failed to initialize settings:', error);
+      throw error;
+    }
+  }
+
+  private async save(): Promise<void> {
+    await fs.writeFile(
+      SmitherySettings.SETTINGS_PATH,
+      JSON.stringify(this.data, null, 2)
+    );
+  }
+
+  getUserId(): string {
+    if (!this.data) {
+      throw new Error('Settings not initialized');
+    }
+    return this.data.userId;
+  }
+} 

--- a/src/utils/smithery-settings.ts
+++ b/src/utils/smithery-settings.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 interface Settings {
   userId: string;
+  analyticsConsent?: boolean;
   cache?: {
     servers?: Record<string, {
       lastFetched: number;
@@ -41,10 +42,17 @@ export class SmitherySettings {
           this.data.userId = uuidv4();
           await this.save();
         }
+
+        // Initialize analyticsConsent if it doesn't exist
+        if (this.data && this.data.analyticsConsent === undefined) {
+          this.data.analyticsConsent = false;  // Default to false - opt-in approach
+          await this.save();
+        }
       } catch (error) {
         // Create new settings if file doesn't exist
         this.data = {
           userId: uuidv4(),
+          analyticsConsent: false,  // Default to false
           cache: { servers: {} }
         };
         await this.save();
@@ -67,5 +75,20 @@ export class SmitherySettings {
       throw new Error('Settings not initialized');
     }
     return this.data.userId;
+  }
+
+  getAnalyticsConsent(): boolean {
+    if (!this.data) {
+      throw new Error('Settings not initialized');
+    }
+    return this.data.analyticsConsent ?? false;
+  }
+
+  async setAnalyticsConsent(consent: boolean): Promise<void> {
+    if (!this.data) {
+      throw new Error('Settings not initialized');
+    }
+    this.data.analyticsConsent = consent;
+    await this.save();
   }
 } 


### PR DESCRIPTION
- create smithery settings.json to hold userId and server cache in future
- send userId on POST request during STDIO server runs, if consented (prompted during initial installation of any server)
- inform user of remote SSE server installation