### PR TITLE
Fix (linux): Prevent hardcoding of user environment variables during build

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -6,6 +6,9 @@ config()
 const define = {}
 
 for (const k in process.env) {
+	/* Skip environment variables that should be evaluated at runtime */
+	if (['HOME', 'USER', 'XDG_CONFIG_HOME'].includes(k)) continue;
+	
 	define[`process.env.${k}`] = JSON.stringify(process.env[k])
 }
 


### PR DESCRIPTION
Fixes installation issues on Linux where paths were incorrectly resolving to /home/runner (https://github.com/smithery-ai/cli/issues/37)