### PR TITLE
feat: Add support for pre-configured server installation data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ npx @smithery/cli <command>
 ### Available Commands
 
 - `install <package>` - Install a package
-  - `--client <name>` - Specify the AI client
+- `--client <name>` - Specify the AI client
+  - `--data <json>` - Provide configuration data as JSON (skips prompts)
 - `uninstall <package>` - Uninstall a package
   - `--client <name>` - Specify the AI client
 - `inspect <server-id>` - Inspect a server interactively
@@ -29,6 +30,9 @@ npx @smithery/cli <command>
 ```bash
 # Install a server (requires --client flag)
 npx @smithery/cli install mcp-obsidian --client claude
+
+# Install a server with pre-configured data (skips prompts)
+npx @smithery/cli install mcp-obsidian --client claude --data '{"apiKey":"your-api-key","region":"us-west-2"}'
 
 # Remove a server
 npx @smithery/cli uninstall mcp-obsidian --client claude

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@types/jest": "^29.5.12",
 				"@types/json-schema": "^7.0.15",
 				"@types/lodash": "^4.17.14",
-				"@types/node": "^14.0.0",
+				"@types/node": "^14.18.63",
 				"@types/ws": "^8.5.14",
 				"dotenv": "^16.4.7",
 				"esbuild": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@types/jest": "^29.5.12",
 		"@types/json-schema": "^7.0.15",
 		"@types/lodash": "^4.17.14",
-		"@types/node": "^14.0.0",
+		"@types/node": "^14.18.63",
 		"@types/ws": "^8.5.14",
 		"dotenv": "^16.4.7",
 		"esbuild": "^0.24.0",


### PR DESCRIPTION
- Update README to document new `--data` flag for server installation
- Modify `index.ts` and `install.ts` to support passing configuration data directly
- Allow skipping interactive prompts by providing configuration as JSON
- Improve installation process to use pre-provided config values when available