### PR TITLE
Use remote flag to choose server connection

### DIFF
--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 export interface RegistryServer {
 	qualifiedName: string
 	displayName: string
+	remote: boolean
 	connections: Array<ConnectionDetails>
 }
 


### PR DESCRIPTION
- Use server's remote flag to identify which connection to choose
- When remote is false, prioritise local connection
- Fallback to first available connection when all conditions fail