### PR TITLE
Fix: run npx in windows through cmd /c

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -40,16 +40,28 @@ function formatServerConfig(
 	/* double stringify config to make it shell-safe */
 	const encodedConfig = JSON.stringify(JSON.stringify(userConfig))
 
+	// Base arguments for npx command
+	const npxArgs = [
+		"-y",
+		"@smithery/cli@latest",
+		"run",
+		qualifiedName,
+		"--config",
+		encodedConfig,
+	]
+
+	// Use cmd /c for Windows platforms
+	if (process.platform === 'win32') {
+		return {
+			command: "cmd",
+			args: ["/c", "npx", ...npxArgs],
+		}
+	}
+
+	// Default for non-Windows platforms
 	return {
 		command: "npx",
-		args: [
-			"-y",
-			"@smithery/cli@latest",
-			"run",
-			qualifiedName,
-			"--config",
-			encodedConfig,
-		],
+		args: npxArgs,
 	}
 }
 

--- a/src/run/stdio-runner.ts
+++ b/src/run/stdio-runner.ts
@@ -114,9 +114,16 @@ export const createStdioRunner = async (
 
 		// Resolve npx path upfront if needed
 		if (finalCommand === 'npx') {
-			console.error('[Runner] Resolving npx path...');
-			finalCommand = await resolveNpxCommand(finalCommand);
+			// console.error('[Runner] Resolving npx path...');
+			// finalCommand = await resolveNpxCommand(finalCommand);
 			console.error('[Runner] Using npx path:', finalCommand);
+			
+			// Special handling for Windows platform
+			if (process.platform === 'win32') {
+				console.error('[Runner] Windows platform detected, using cmd /c for npx');
+				finalArgs = ['/c', 'npx', ...finalArgs];
+				finalCommand = 'cmd';
+			}
 		}
 
 		console.error("[Runner] Executing:", {


### PR DESCRIPTION
- workaround until SDK is fixed to allow running servers in windows without additional ```cmd /c``` args
- https://github.com/modelcontextprotocol/typescript-sdk/issues/101
- https://github.com/smithery-ai/mcp-obsidian/issues/19