### PR TITLE
Improve server config formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.53] - 2025-03-28
 
 ### Changed
-- Updated server configuration handling to skip the `--config` flag when configuration is empty, resulting in cleaner command execution
+- Updated server configuration handling to skip the `--config` flag when configuration is empty, for cleaner command execution
 
 ## [1.1.52] - 2025-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.53] - 2025-03-28
+## [1.1.53] - 2025-03-24
 
 ### Changed
 - Updated server configuration handling to skip the `--config` flag when configuration is empty, for cleaner command execution
 
-## [1.1.52] - 2025-03-27
+## [1.1.52] - 2025-03-24
 
 ### Fixed
 - Fixed destructuring issue in collectConfigValues() that was causing parsing error with inspect command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.53] - 2025-03-28
+
+### Changed
+- Updated server configuration handling to skip the `--config` flag when configuration is empty, resulting in cleaner command execution
+
 ## [1.1.52] - 2025-03-27
 
 ### Fixed

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -419,7 +419,13 @@ export function formatServerConfig(
 		npxArgs.push("--key", apiKey)
 	}
 
-	if (!apiKey || configNeeded) {
+	/**
+	 * Add config flag in these scenarios:
+	 * 1. api key is not given OR config is needed (configNeeded prop)
+	 * 2. config is not empty
+	 */
+	const isEmptyConfig = Object.keys(userConfig).length === 0
+	if (!isEmptyConfig && (!apiKey || configNeeded)) {
 		/* double stringify config to make it shell-safe */
 		const encodedConfig = JSON.stringify(JSON.stringify(userConfig))
 		npxArgs.push("--config", encodedConfig)


### PR DESCRIPTION
Updated server configuration handling to skip the `--config` flag when configuration is empty, for cleaner commands