### PR TITLE
feat: support installing servers to vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.63] - 2025-03-31
+
+### Added
+- Added support for VS Code and VS Code Insiders
+
 ## [1.1.62] - 2025-03-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -49,11 +49,7 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.0.0"
 	},
-	"files": [
-		"dist",
-		"README.md",
-		"package.json"
-	],
+	"files": ["dist", "README.md", "package.json"],
 	"exports": {
 		".": {
 			"import": "./dist/index.js"

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -3,10 +3,23 @@ import os from "node:os"
 import path from "node:path"
 import type { MCPConfig } from "./types/registry.js"
 import { verbose } from "./logger"
+import { execFileSync } from "node:child_process"
 
 export interface ClientConfig extends MCPConfig {
 	[key: string]: any
 }
+
+interface ClientFileTarget {
+	type: "file"
+	path: string
+}
+
+interface ClientCommandTarget {
+	type: "command"
+	command: string
+}
+
+type ClientInstallTarget = ClientCommandTarget | ClientFileTarget
 
 // Initialize platform-specific paths
 const homeDir = os.homedir()
@@ -28,60 +41,92 @@ const platformPaths = {
 
 const platform = process.platform as keyof typeof platformPaths
 const { baseDir, vscodePath } = platformPaths[platform]
+const defaultClaudePath = path.join(
+	baseDir,
+	"Claude",
+	"claude_desktop_config.json",
+)
 
 // Define client paths using the platform-specific base directories
-const clientPaths: { [key: string]: string } = {
-	claude: path.join(baseDir, "Claude", "claude_desktop_config.json"),
-	cline: path.join(
-		baseDir,
-		vscodePath,
-		"saoudrizwan.claude-dev",
-		"settings",
-		"cline_mcp_settings.json",
-	),
-	"roo-cline": path.join(
-		baseDir,
-		vscodePath,
-		"rooveterinaryinc.roo-cline",
-		"settings",
-		"cline_mcp_settings.json",
-	),
-	windsurf: path.join(homeDir, ".codeium", "windsurf", "mcp_config.json"),
-	witsy: path.join(baseDir, "Witsy", "settings.json"),
-	enconvo: path.join(homeDir, ".config", "enconvo", "mcp_config.json"),
-	cursor: path.join(homeDir, ".cursor", "mcp.json"),
+const clientPaths: { [key: string]: ClientInstallTarget } = {
+	claude: { type: "file", path: defaultClaudePath },
+	cline: {
+		type: "file",
+		path: path.join(
+			baseDir,
+			vscodePath,
+			"saoudrizwan.claude-dev",
+			"settings",
+			"cline_mcp_settings.json",
+		),
+	},
+	"roo-cline": {
+		type: "file",
+		path: path.join(
+			baseDir,
+			vscodePath,
+			"rooveterinaryinc.roo-cline",
+			"settings",
+			"cline_mcp_settings.json",
+		),
+	},
+	windsurf: {
+		type: "file",
+		path: path.join(homeDir, ".codeium", "windsurf", "mcp_config.json"),
+	},
+	witsy: { type: "file", path: path.join(baseDir, "Witsy", "settings.json") },
+	enconvo: {
+		type: "file",
+		path: path.join(homeDir, ".config", "enconvo", "mcp_config.json"),
+	},
+	cursor: { type: "file", path: path.join(homeDir, ".cursor", "mcp.json") },
+	vscode: {
+		type: "command",
+		command: process.platform === "win32" ? "code.cmd" : "code",
+	},
+	"vscode-insiders": {
+		type: "command",
+		command:
+			process.platform === "win32" ? "code-insiders.cmd" : "code-insiders",
+	},
 }
 
-export function getConfigPath(client?: string): string {
+export function getConfigPath(client?: string): ClientInstallTarget {
 	const normalizedClient = client?.toLowerCase() || "claude"
 	verbose(`Getting config path for client: ${normalizedClient}`)
 
-	const configPath =
-		clientPaths[normalizedClient] ||
-		path.join(
-			path.dirname(clientPaths.claude),
+	const configTarget = clientPaths[normalizedClient] || {
+		type: "file",
+		path: path.join(
+			path.dirname(defaultClaudePath),
 			"..",
 			client || "claude",
 			`${normalizedClient}_config.json`,
-		)
+		),
+	}
 
-	verbose(`Config path resolved to: ${configPath}`)
-	return configPath
+	verbose(`Config path resolved to: ${JSON.stringify(configTarget)}`)
+	return configTarget
 }
 
 export function readConfig(client: string): ClientConfig {
 	verbose(`Reading config for client: ${client}`)
 	try {
 		const configPath = getConfigPath(client)
-		verbose(`Checking if config file exists at: ${configPath}`)
 
-		if (!fs.existsSync(configPath)) {
+		// Command-based installers (i.e. VS Code) do not currently support listing servers
+		if (configPath.type === "command") {
+			return { mcpServers: {} }
+		}
+
+		verbose(`Checking if config file exists at: ${configPath}`)
+		if (!fs.existsSync(configPath.path)) {
 			verbose(`Config file not found, returning default empty config`)
 			return { mcpServers: {} }
 		}
 
 		verbose(`Reading config file content`)
-		const rawConfig = JSON.parse(fs.readFileSync(configPath, "utf8"))
+		const rawConfig = JSON.parse(fs.readFileSync(configPath.path, "utf8"))
 		verbose(`Config loaded successfully: ${JSON.stringify(rawConfig, null, 2)}`)
 
 		return {
@@ -100,8 +145,50 @@ export function writeConfig(config: ClientConfig, client?: string): void {
 	verbose(`Writing config for client: ${client || "default"}`)
 	verbose(`Config data: ${JSON.stringify(config, null, 2)}`)
 
+	if (!config.mcpServers || typeof config.mcpServers !== "object") {
+		verbose(`Invalid mcpServers structure in config`)
+		throw new Error("Invalid mcpServers structure")
+	}
+
 	const configPath = getConfigPath(client)
-	const configDir = path.dirname(configPath)
+	if (configPath.type === "command") {
+		writeConfigCommand(config, configPath)
+	} else {
+		writeConfigFile(config, configPath)
+	}
+}
+
+function writeConfigCommand(
+	config: ClientConfig,
+	target: ClientCommandTarget,
+): void {
+	const args: string[] = []
+	for (const [name, server] of Object.entries(config.mcpServers)) {
+		args.push("--add-mcp", JSON.stringify({ ...server, name }))
+	}
+
+	verbose(`Running command: ${JSON.stringify([target.command, ...args])}`)
+
+	try {
+		const output = execFileSync(target.command, args)
+		verbose(`Executed command successfully: ${output.toString()}`)
+	} catch (error) {
+		verbose(
+			`Error executing command: ${error instanceof Error ? error.message : String(error)}`,
+		)
+
+		if (error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+			throw new Error(
+				`Command '${target.command}' not found. Make sure ${target.command} is installed and on your PATH`,
+			)
+		}
+
+		throw error
+	}
+}
+
+function writeConfigFile(config: ClientConfig, target: ClientFileTarget): void {
+	const configDir = path.dirname(target.path)
 
 	verbose(`Ensuring config directory exists: ${configDir}`)
 	if (!fs.existsSync(configDir)) {
@@ -109,16 +196,11 @@ export function writeConfig(config: ClientConfig, client?: string): void {
 		fs.mkdirSync(configDir, { recursive: true })
 	}
 
-	if (!config.mcpServers || typeof config.mcpServers !== "object") {
-		verbose(`Invalid mcpServers structure in config`)
-		throw new Error("Invalid mcpServers structure")
-	}
-
 	let existingConfig: ClientConfig = { mcpServers: {} }
 	try {
-		if (fs.existsSync(configPath)) {
+		if (fs.existsSync(target.path)) {
 			verbose(`Reading existing config file for merging`)
-			existingConfig = JSON.parse(fs.readFileSync(configPath, "utf8"))
+			existingConfig = JSON.parse(fs.readFileSync(target.path, "utf8"))
 			verbose(
 				`Existing config loaded: ${JSON.stringify(existingConfig, null, 2)}`,
 			)
@@ -137,7 +219,7 @@ export function writeConfig(config: ClientConfig, client?: string): void {
 	}
 	verbose(`Merged config: ${JSON.stringify(mergedConfig, null, 2)}`)
 
-	verbose(`Writing config to file: ${configPath}`)
-	fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2))
+	verbose(`Writing config to file: ${target.path}`)
+	fs.writeFileSync(target.path, JSON.stringify(mergedConfig, null, 2))
 	verbose(`Config successfully written`)
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,4 @@
-import { readConfig } from "../client-config"
+import { readConfig, getConfigPath } from "../client-config"
 import { VALID_CLIENTS, type ValidClient } from "../constants"
 import chalk from "chalk"
 
@@ -12,16 +12,27 @@ export async function list(
 			VALID_CLIENTS.forEach((client) => console.log(`  ${chalk.green(client)}`))
 			break
 		case "servers": {
+			/* check if client is command-type */
+			const configTarget = getConfigPath(client)
+			if (configTarget.type === "command") {
+				console.log(
+					chalk.yellow(
+						`Listing servers is currently not supported for ${client}`,
+					),
+				)
+				return
+			}
+
 			const config = readConfig(client)
 			const servers = Object.keys(config.mcpServers)
 			if (servers?.length > 0) {
 				console.log(chalk.bold(`Installed servers for ${client}:`))
 				servers.sort().forEach((server) => {
-					console.log(`  ${chalk.green(server)}`)
+					console.log(`${chalk.green(server)}`)
 				})
 			} else {
 				const info = `No installed servers found for ${client}`
-				console.log(`  ${chalk.red(info)}`)
+				console.log(`${chalk.red(info)}`)
 			}
 
 			break

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -12,41 +12,46 @@ process.on("warning", (warning) => {
 
 import type { ValidClient } from "../constants"
 import { promptForRestart } from "../utils/client"
-import { normalizeServerId } from "../utils/config"
+import { getConfigPath } from "../client-config"
 import { readConfig, writeConfig } from "../client-config"
 import chalk from "chalk"
-import ora from "ora"
 
 /* uninstalls server for given client */
 export async function uninstallServer(
 	qualifiedName: string,
 	client: ValidClient,
 ): Promise<void> {
-	const spinner = ora(`Uninstalling ${qualifiedName}...`).start()
-
 	try {
+		/* check if client is command-type */
+		const configTarget = getConfigPath(client)
+		if (configTarget.type === "command") {
+			console.log(
+				chalk.yellow(`Uninstallation is currently not supported for ${client}`),
+			)
+			return
+		}
+
 		/* read config from client */
 		const config = readConfig(client)
-		const normalizedName = normalizeServerId(qualifiedName)
 
 		/* check if server exists in config */
-		if (!config.mcpServers[normalizedName]) {
-			spinner.fail(`Server ${qualifiedName} is not installed for ${client}`)
+		if (!config.mcpServers[qualifiedName]) {
+			console.log(
+				chalk.red(`Server ${qualifiedName} is not installed for ${client}`),
+			)
 			return
 		}
 
 		/* remove server from config */
-		delete config.mcpServers[normalizedName]
+		delete config.mcpServers[qualifiedName]
 		writeConfig(config, client)
 
-		spinner.succeed(`Successfully uninstalled ${qualifiedName}`)
 		console.log(
 			chalk.green(`${qualifiedName} successfully uninstalled from ${client}`),
 		)
 
 		await promptForRestart(client)
 	} catch (error) {
-		spinner.fail(`Failed to uninstall ${qualifiedName}`)
 		if (error instanceof Error) {
 			console.error(chalk.red(`Error: ${error.message}`))
 		} else {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,8 @@ export const VALID_CLIENTS = [
 	"witsy",
 	"enconvo",
 	"cursor",
+	"vscode",
+	"vscode-insiders",
 ] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
 

--- a/src/test/config-manager.test.ts
+++ b/src/test/config-manager.test.ts
@@ -179,13 +179,19 @@ describe("Client Config", () => {
 
 	describe("Config Path Resolution", () => {
 		it("should get correct config path for known client", () => {
-			const configPath = clientConfig.getConfigPath("claude")
-			expect(configPath).toContain("claude_desktop_config.json")
+			const configTarget = clientConfig.getConfigPath("claude")
+			if (configTarget.type !== "file") {
+				throw new Error("Expected config target to be a file")
+			}
+			expect(configTarget.path).toContain("claude_desktop_config.json")
 		})
 
 		it("should handle unknown client with fallback path", () => {
-			const configPath = clientConfig.getConfigPath("unknown-client")
-			expect(configPath).toContain("unknown-client")
+			const configTarget = clientConfig.getConfigPath("unknown-client")
+			if (configTarget.type !== "file") {
+				throw new Error("Expected config target to be a file")
+			}
+			expect(configTarget.path).toContain("unknown-client")
 		})
 	})
 })


### PR DESCRIPTION
I tried to keep the change somewhat minimal. Switched from a `string` config to a type that points either to a config or a command. Reading a "command" config will return no servers right now, since VS Code doesn't support that. I validated that you can successfully install them on macOS and Windows and that existing install configs work.

Refs https://github.com/smithery-ai/cli/issues/76