### PR TITLE
fix: windows cmd json parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.63] - 2025-03-31
+## [1.1.64] - 2025-04-01
+
+### Fixed
+- Fixed config parsing on Windows command prompt where single quotes were being passed literally instead of being interpreted
+
+## [1.1.63] - 2025-04-01
 
 ### Added
 - Added support for VS Code and VS Code Insiders

--- a/package.json
+++ b/package.json
@@ -49,11 +49,7 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.0.0"
 	},
-	"files": [
-		"dist",
-		"README.md",
-		"package.json"
-	],
+	"files": ["dist", "README.md", "package.json"],
 	"exports": {
 		".": {
 			"import": "./dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,12 @@ const config: ServerConfig =
 	configFlag !== -1
 		? (() => {
 				try {
-					let parsedConfig = JSON.parse(process.argv[configFlag + 1])
+					let rawConfig = process.argv[configFlag + 1]
+					// Windows cmd does not interpret `'`, passes it literally
+					if (rawConfig.startsWith("'") && rawConfig.endsWith("'")) {
+						rawConfig = rawConfig.slice(1, -1)
+					}
+					let parsedConfig = JSON.parse(rawConfig)
 					if (typeof parsedConfig === "string") {
 						parsedConfig = JSON.parse(parsedConfig)
 					}


### PR DESCRIPTION
Fixed config parsing on Windows command prompt where single quotes were being passed literally instead of being interpreted