### PR TITLE
add support for amazon-bedrock

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -90,6 +90,10 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
 			process.platform === "win32" ? "code-insiders.cmd" : "code-insiders",
 	},
 	boltai: { type: "file", path: path.join(homeDir, ".boltai", "mcp.json") },
+	"amazon-bedrock-client": {
+		type: "file",
+		path: path.join(homeDir, "Amazon Bedrock Client", "mcp_config.json"),
+	},
 }
 
 export function getConfigPath(client?: string): ClientInstallTarget {

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -90,7 +90,7 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
 			process.platform === "win32" ? "code-insiders.cmd" : "code-insiders",
 	},
 	boltai: { type: "file", path: path.join(homeDir, ".boltai", "mcp.json") },
-	"amazon-bedrock-client": {
+	"amazon-bedrock": {
 		type: "file",
 		path: path.join(homeDir, "Amazon Bedrock Client", "mcp_config.json"),
 	},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const VALID_CLIENTS = [
 	"vscode",
 	"vscode-insiders",
 	"boltai",
+	"amazon-bedrock-client",
 ] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const VALID_CLIENTS = [
 	"vscode",
 	"vscode-insiders",
 	"boltai",
-	"amazon-bedrock-client",
+	"amazon-bedrock",
 ] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
 


### PR DESCRIPTION
[Amazon Bedrock Client for Mac](https://github.com/aws-samples/amazon-bedrock-client-for-mac) provides an mcp client for use with Amazon Bedrock models in MacOS environment. Below is a test run.

install @mcp-examples/weather
![스크린샷 2025-04-22 오후 2 14 01](https://github.com/user-attachments/assets/ea1c6503-3e04-4c34-b590-ac90e511ee8c)

mcp settings applied
![435914841-b3a9f871-c7af-49f5-a604-1530521569ac](https://github.com/user-attachments/assets/8f6c9e37-9e2d-40f3-91df-7e34c147f8a2)

client uses tool
![image](https://github.com/user-attachments/assets/dd9d9960-e348-4bca-a9c3-0da7e3c4d5f8)
