### PR TITLE
chore: add repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"type": "commonjs",
 	"private": false,
 	"homepage": "https://smithery.ai/",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/smithery-ai/cli.git"
+	},
 	"description": "A NPX command to install and list Model Context Protocols from Smithery",
 	"main": "dist/index.js",
 	"scripts": {


### PR DESCRIPTION
This PR adds the [`repository` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) to `package.json`.

Since the docs recommend running this with `npx`, I wanted to look at the source code. A common pattern I use is `npm repo <package-name`. However, this didn't work with `@smithery-ai/cli`:

```shell
> npm repo @smithery/cli
npm error no repository
```

Adding this key will make it easier for users to validate the source code for the CLI tool.