### PR TITLE
add amazonq client

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -94,6 +94,10 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
 		type: "file",
 		path: path.join(homeDir, "Amazon Bedrock Client", "mcp_config.json"),
 	},
+	amazonq: {
+		type: "file",
+		path: path.join(homeDir, ".aws", "amazonq", "mcp.json"),
+	},
 }
 
 export function getConfigPath(client?: string): ClientInstallTarget {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const VALID_CLIENTS = [
 	"vscode-insiders",
 	"boltai",
 	"amazon-bedrock",
+	"amazonq",
 ] as const
 export type ValidClient = (typeof VALID_CLIENTS)[number]
 


### PR DESCRIPTION
As described in this [AWS MCP blog](https://aws.amazon.com/blogs/devops/extend-the-amazon-q-developer-cli-with-mcp/#:~:text=the%20database%20schema.-,configuring,-Model%20Context%20Protocol) post, this PR should add support for Amazon Q.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/a959075d-9ed9-4692-94c8-211bba7ee8cd" />

Amazon Q using smithery installed MCP servers:

<img width="731" alt="image" src="https://github.com/user-attachments/assets/c991aae5-46dc-411e-8701-d5aa4cb0986d" />
