### PR TITLE
devex around playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,7 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.0.0"
 	},
-	"files": [
-		"dist",
-		"README.md",
-		"package.json"
-	],
+	"files": ["dist", "README.md", "package.json"],
 	"exports": {
 		".": {
 			"import": "./dist/index.js"

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,170 +1,175 @@
-import chalk from "chalk";
-import { join } from "node:path";
-import { spawn, type ChildProcess } from "node:child_process";
-import { setupTunnelAndPlayground } from "../lib/dev-lifecycle";
-import { ensureApiKey } from "../utils/runtime";
-import { buildMcpServer } from "../lib/build";
-import { existsSync } from "node:fs";
+import chalk from "chalk"
+import { join } from "node:path"
+import { spawn, type ChildProcess } from "node:child_process"
+import { setupTunnelAndPlayground } from "../lib/dev-lifecycle"
+import { ensureApiKey } from "../utils/runtime"
+import { buildMcpServer } from "../lib/build"
+import { existsSync } from "node:fs"
+import { debug } from "../logger"
 
 interface DevOptions {
-  entryFile?: string;
-  port?: string;
-  key?: string;
-  open?: boolean;
+	entryFile?: string
+	port?: string
+	key?: string
+	open?: boolean
 }
 
 export async function dev(options: DevOptions = {}): Promise<void> {
-  try {
-    // Ensure API key is available
-    const apiKey = await ensureApiKey(options.key);
+	try {
+		// Ensure API key is available
+		const apiKey = await ensureApiKey(options.key)
 
-    const smitheryDir = join(".smithery");
-    const outFile = join(smitheryDir, "index.cjs");
-    const finalPort = options.port || "8181";
+		const smitheryDir = join(".smithery")
+		const outFile = join(smitheryDir, "index.cjs")
+		const finalPort = options.port || "8181"
 
-    let childProcess: ChildProcess | undefined;
-    let tunnelListener: { close: () => Promise<void> } | undefined;
-    let isFirstBuild = true;
-    let isRebuilding = false;
+		let childProcess: ChildProcess | undefined
+		let tunnelListener: { close: () => Promise<void> } | undefined
+		let isFirstBuild = true
+		let isRebuilding = false
 
-    // Function to start the server process
-    const startServer = async () => {
-      // Kill existing process
-      if (childProcess && !childProcess.killed) {
-        isRebuilding = true;
-        childProcess.kill("SIGTERM");
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+		// Function to start the server process
+		const startServer = async () => {
+			// Kill existing process
+			if (childProcess && !childProcess.killed) {
+				isRebuilding = true
+				childProcess.kill("SIGTERM")
+				await new Promise((resolve) => setTimeout(resolve, 100))
+			}
 
-      // Ensure the output file exists before starting the process (handles async fs write timing)
-      await new Promise<void>((resolve) => {
-        if (existsSync(outFile)) {
-          return resolve();
-        }
-        const interval = setInterval(() => {
-          if (existsSync(outFile)) {
-            clearInterval(interval);
-            resolve();
-          }
-        }, 50);
-      });
+			// Ensure the output file exists before starting the process (handles async fs write timing)
+			await new Promise<void>((resolve) => {
+				if (existsSync(outFile)) {
+					return resolve()
+				}
+				const interval = setInterval(() => {
+					if (existsSync(outFile)) {
+						clearInterval(interval)
+						resolve()
+					}
+				}, 50)
+			})
 
-      // Start new process with tsx loader so .ts imports work in runtime bootstrap
-      childProcess = spawn(
-        "node",
-        ["--import", "tsx", join(process.cwd(), outFile)],
-        {
-          stdio: ["inherit", "pipe", "pipe"],
-          env: {
-            ...process.env,
-            PORT: finalPort,
-          },
-        }
-      );
+			// Start new process with tsx loader so .ts imports work in runtime bootstrap
+			childProcess = spawn(
+				"node",
+				["--import", "tsx", join(process.cwd(), outFile)],
+				{
+					stdio: ["inherit", "pipe", "pipe"],
+					env: {
+						...process.env,
+						PORT: finalPort,
+					},
+				},
+			)
 
-      const processOutput = (data: Buffer) => {
-        const chunk = data.toString();
-        process.stdout.write(chunk);
-      };
+			const processOutput = (data: Buffer) => {
+				const chunk = data.toString()
+				process.stdout.write(chunk)
+			}
 
-      childProcess.stdout?.on("data", processOutput);
-      childProcess.stderr?.on("data", (data) => {
-        const chunk = data.toString();
-        process.stderr.write(chunk);
-      });
+			childProcess.stdout?.on("data", processOutput)
+			childProcess.stderr?.on("data", (data) => {
+				const chunk = data.toString()
+				process.stderr.write(chunk)
+			})
 
-      childProcess.on("error", (error) => {
-        console.error(chalk.red("❌ Process error:"), error);
-        cleanup();
-      });
+			childProcess.on("error", (error) => {
+				console.error(chalk.red("❌ Process error:"), error)
+				cleanup()
+			})
 
-      childProcess.on("exit", (code) => {
-        // Ignore exits during rebuilds - this is expected behavior
-        if (isRebuilding) {
-          isRebuilding = false;
-          return;
-        }
+			childProcess.on("exit", (code) => {
+				// Ignore exits during rebuilds - this is expected behavior
+				if (isRebuilding) {
+					isRebuilding = false
+					return
+				}
 
-        if (code !== 0 && code !== null) {
-          console.log(chalk.yellow(`⚠️  Process exited with code ${code}`));
-          cleanup();
-        }
-      });
+				if (code !== 0 && code !== null) {
+					console.log(chalk.yellow(`⚠️  Process exited with code ${code}`))
+					cleanup()
+				}
+			})
 
-      // Start tunnel and open playground on first successful start
-      if (isFirstBuild) {
-        console.log(chalk.green(`✅ Server starting on port ${finalPort}`));
-        setupTunnelAndPlayground(finalPort, apiKey, options.open !== false)
-          .then(({ listener }) => {
-            tunnelListener = listener;
-            isFirstBuild = false;
-          })
-          .catch((error) => {
-            console.error(chalk.red("❌ Failed to start tunnel:"), error);
-          });
-      }
-    };
+			// Start tunnel and open playground on first successful start
+			if (isFirstBuild) {
+				console.log(chalk.green(`✅ Server starting on port ${finalPort}`))
+				setupTunnelAndPlayground(finalPort, apiKey, options.open !== false)
+					.then(({ listener }) => {
+						tunnelListener = listener
+						isFirstBuild = false
+					})
+					.catch((error) => {
+						console.error(chalk.red("❌ Failed to start tunnel:"), error)
+					})
+			}
+		}
 
-    // Set up build with watch mode
-    const buildContext = await buildMcpServer({
-      outFile,
-      entryFile: options.entryFile,
-      watch: true,
-      onRebuild: () => {
-        startServer();
-      },
-    });
+		// Set up build with watch mode
+		const buildContext = await buildMcpServer({
+			outFile,
+			entryFile: options.entryFile,
+			watch: true,
+			onRebuild: () => {
+				startServer()
+			},
+		})
 
-    // Handle cleanup on exit
-    const cleanup = async () => {
-      console.log(chalk.yellow("\n👋 Shutting down dev server..."));
+		// Handle cleanup on exit
+		const cleanup = async () => {
+			console.log(chalk.yellow("\n👋 Shutting down dev server..."))
 
-      // Stop watching
-      if (buildContext && "dispose" in buildContext) {
-        await buildContext.dispose();
-      }
+			// Stop watching
+			if (buildContext && "dispose" in buildContext) {
+				await buildContext.dispose()
+			}
 
-      // Close tunnel
-      if (tunnelListener) {
-        try {
-          await tunnelListener.close();
-          console.log(chalk.green("Tunnel closed"));
-        } catch (error) {
-          console.log(chalk.yellow("Tunnel already closed"));
-        }
-      }
+			// Close tunnel
+			if (tunnelListener) {
+				try {
+					await tunnelListener.close()
+					debug(chalk.green("Tunnel closed"))
+				} catch (error) {
+					debug(chalk.yellow("Tunnel already closed"))
+				}
+			}
 
-      // Kill child process
-      if (childProcess && !childProcess.killed) {
-        console.log(chalk.yellow("Stopping MCP server..."));
-        console.log(
-          `\n\n${chalk.white(
-            "Thanks so much for using Smithery!"
-          )}\n🚀 One-click cloud deploy: ${chalk.blue.underline(
-            "https://smithery.ai/new"
-          )}\n\n`
-        );
-        childProcess.kill("SIGTERM");
+			// Kill child process
+			if (childProcess && !childProcess.killed) {
+				console.log(chalk.yellow("Stopping MCP server..."))
+				console.log(
+					`\n\n${chalk.rgb(
+						234,
+						88,
+						12,
+					)(
+						"Thanks for using Smithery!",
+					)}\n🚀 One-click cloud deploy: ${chalk.blue.underline(
+						"https://smithery.ai/new",
+					)}\n\n`,
+				)
+				childProcess.kill("SIGTERM")
 
-        // Force kill after 5 seconds
-        setTimeout(() => {
-          if (childProcess && !childProcess.killed) {
-            childProcess.kill("SIGKILL");
-          }
-        }, 5000);
-      }
+				// Force kill after 5 seconds
+				setTimeout(() => {
+					if (childProcess && !childProcess.killed) {
+						childProcess.kill("SIGKILL")
+					}
+				}, 5000)
+			}
 
-      process.exit(0);
-    };
+			process.exit(0)
+		}
 
-    // Set up signal handlers
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+		// Set up signal handlers
+		process.on("SIGINT", cleanup)
+		process.on("SIGTERM", cleanup)
 
-    // Keep the process alive
-    await new Promise<void>(() => {});
-  } catch (error) {
-    console.error(chalk.red("❌ Dev server failed:"), error);
-    process.exit(1);
-  }
+		// Keep the process alive
+		await new Promise<void>(() => {})
+	} catch (error) {
+		console.error(chalk.red("❌ Dev server failed:"), error)
+		process.exit(1)
+	}
 }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -12,6 +12,7 @@ interface DevOptions {
 	port?: string
 	key?: string
 	open?: boolean
+	initialMessage?: string
 }
 
 export async function dev(options: DevOptions = {}): Promise<void> {
@@ -95,7 +96,12 @@ export async function dev(options: DevOptions = {}): Promise<void> {
 			// Start tunnel and open playground on first successful start
 			if (isFirstBuild) {
 				console.log(chalk.green(`✅ Server starting on port ${finalPort}`))
-				setupTunnelAndPlayground(finalPort, apiKey, options.open !== false)
+				setupTunnelAndPlayground(
+					finalPort,
+					apiKey,
+					options.open !== false,
+					options.initialMessage,
+				)
 					.then(({ listener }) => {
 						tunnelListener = listener
 						isFirstBuild = false

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,163 +1,170 @@
-import chalk from "chalk"
-import { join } from "node:path"
-import { spawn, type ChildProcess } from "node:child_process"
-import { setupTunnelAndPlayground } from "../lib/dev-lifecycle"
-import { ensureApiKey } from "../utils/runtime"
-import { buildMcpServer } from "../lib/build"
-import { existsSync } from "node:fs"
+import chalk from "chalk";
+import { join } from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { setupTunnelAndPlayground } from "../lib/dev-lifecycle";
+import { ensureApiKey } from "../utils/runtime";
+import { buildMcpServer } from "../lib/build";
+import { existsSync } from "node:fs";
 
 interface DevOptions {
-	entryFile?: string
-	port?: string
-	key?: string
-	open?: boolean
+  entryFile?: string;
+  port?: string;
+  key?: string;
+  open?: boolean;
 }
 
 export async function dev(options: DevOptions = {}): Promise<void> {
-	try {
-		// Ensure API key is available
-		const apiKey = await ensureApiKey(options.key)
+  try {
+    // Ensure API key is available
+    const apiKey = await ensureApiKey(options.key);
 
-		const smitheryDir = join(".smithery")
-		const outFile = join(smitheryDir, "index.cjs")
-		const finalPort = options.port || "8181"
+    const smitheryDir = join(".smithery");
+    const outFile = join(smitheryDir, "index.cjs");
+    const finalPort = options.port || "8181";
 
-		let childProcess: ChildProcess | undefined
-		let tunnelListener: { close: () => Promise<void> } | undefined
-		let isFirstBuild = true
-		let isRebuilding = false
+    let childProcess: ChildProcess | undefined;
+    let tunnelListener: { close: () => Promise<void> } | undefined;
+    let isFirstBuild = true;
+    let isRebuilding = false;
 
-		// Function to start the server process
-		const startServer = async () => {
-			// Kill existing process
-			if (childProcess && !childProcess.killed) {
-				isRebuilding = true
-				childProcess.kill("SIGTERM")
-				await new Promise((resolve) => setTimeout(resolve, 100))
-			}
+    // Function to start the server process
+    const startServer = async () => {
+      // Kill existing process
+      if (childProcess && !childProcess.killed) {
+        isRebuilding = true;
+        childProcess.kill("SIGTERM");
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
 
-			// Ensure the output file exists before starting the process (handles async fs write timing)
-			await new Promise<void>((resolve) => {
-				if (existsSync(outFile)) {
-					return resolve()
-				}
-				const interval = setInterval(() => {
-					if (existsSync(outFile)) {
-						clearInterval(interval)
-						resolve()
-					}
-				}, 50)
-			})
+      // Ensure the output file exists before starting the process (handles async fs write timing)
+      await new Promise<void>((resolve) => {
+        if (existsSync(outFile)) {
+          return resolve();
+        }
+        const interval = setInterval(() => {
+          if (existsSync(outFile)) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 50);
+      });
 
-			// Start new process with tsx loader so .ts imports work in runtime bootstrap
-			childProcess = spawn(
-				"node",
-				["--import", "tsx", join(process.cwd(), outFile)],
-				{
-					stdio: ["inherit", "pipe", "pipe"],
-					env: {
-						...process.env,
-						PORT: finalPort,
-					},
-				},
-			)
+      // Start new process with tsx loader so .ts imports work in runtime bootstrap
+      childProcess = spawn(
+        "node",
+        ["--import", "tsx", join(process.cwd(), outFile)],
+        {
+          stdio: ["inherit", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            PORT: finalPort,
+          },
+        }
+      );
 
-			const processOutput = (data: Buffer) => {
-				const chunk = data.toString()
-				process.stdout.write(chunk)
-			}
+      const processOutput = (data: Buffer) => {
+        const chunk = data.toString();
+        process.stdout.write(chunk);
+      };
 
-			childProcess.stdout?.on("data", processOutput)
-			childProcess.stderr?.on("data", (data) => {
-				const chunk = data.toString()
-				process.stderr.write(chunk)
-			})
+      childProcess.stdout?.on("data", processOutput);
+      childProcess.stderr?.on("data", (data) => {
+        const chunk = data.toString();
+        process.stderr.write(chunk);
+      });
 
-			childProcess.on("error", (error) => {
-				console.error(chalk.red("❌ Process error:"), error)
-				cleanup()
-			})
+      childProcess.on("error", (error) => {
+        console.error(chalk.red("❌ Process error:"), error);
+        cleanup();
+      });
 
-			childProcess.on("exit", (code) => {
-				// Ignore exits during rebuilds - this is expected behavior
-				if (isRebuilding) {
-					isRebuilding = false
-					return
-				}
+      childProcess.on("exit", (code) => {
+        // Ignore exits during rebuilds - this is expected behavior
+        if (isRebuilding) {
+          isRebuilding = false;
+          return;
+        }
 
-				if (code !== 0 && code !== null) {
-					console.log(chalk.yellow(`⚠️  Process exited with code ${code}`))
-					cleanup()
-				}
-			})
+        if (code !== 0 && code !== null) {
+          console.log(chalk.yellow(`⚠️  Process exited with code ${code}`));
+          cleanup();
+        }
+      });
 
-			// Start tunnel and open playground on first successful start
-			if (isFirstBuild) {
-				console.log(chalk.green(`✅ Server starting on port ${finalPort}`))
-				setupTunnelAndPlayground(finalPort, apiKey, options.open !== false)
-					.then(({ listener }) => {
-						tunnelListener = listener
-						isFirstBuild = false
-					})
-					.catch((error) => {
-						console.error(chalk.red("❌ Failed to start tunnel:"), error)
-					})
-			}
-		}
+      // Start tunnel and open playground on first successful start
+      if (isFirstBuild) {
+        console.log(chalk.green(`✅ Server starting on port ${finalPort}`));
+        setupTunnelAndPlayground(finalPort, apiKey, options.open !== false)
+          .then(({ listener }) => {
+            tunnelListener = listener;
+            isFirstBuild = false;
+          })
+          .catch((error) => {
+            console.error(chalk.red("❌ Failed to start tunnel:"), error);
+          });
+      }
+    };
 
-		// Set up build with watch mode
-		const buildContext = await buildMcpServer({
-			outFile,
-			entryFile: options.entryFile,
-			watch: true,
-			onRebuild: () => {
-				startServer()
-			},
-		})
+    // Set up build with watch mode
+    const buildContext = await buildMcpServer({
+      outFile,
+      entryFile: options.entryFile,
+      watch: true,
+      onRebuild: () => {
+        startServer();
+      },
+    });
 
-		// Handle cleanup on exit
-		const cleanup = async () => {
-			console.log(chalk.yellow("\n👋 Shutting down dev server..."))
+    // Handle cleanup on exit
+    const cleanup = async () => {
+      console.log(chalk.yellow("\n👋 Shutting down dev server..."));
 
-			// Stop watching
-			if (buildContext && "dispose" in buildContext) {
-				await buildContext.dispose()
-			}
+      // Stop watching
+      if (buildContext && "dispose" in buildContext) {
+        await buildContext.dispose();
+      }
 
-			// Close tunnel
-			if (tunnelListener) {
-				try {
-					await tunnelListener.close()
-					console.log(chalk.green("Tunnel closed"))
-				} catch (error) {
-					console.log(chalk.yellow("Tunnel already closed"))
-				}
-			}
+      // Close tunnel
+      if (tunnelListener) {
+        try {
+          await tunnelListener.close();
+          console.log(chalk.green("Tunnel closed"));
+        } catch (error) {
+          console.log(chalk.yellow("Tunnel already closed"));
+        }
+      }
 
-			// Kill child process
-			if (childProcess && !childProcess.killed) {
-				console.log(chalk.yellow("Stopping MCP server..."))
-				childProcess.kill("SIGTERM")
+      // Kill child process
+      if (childProcess && !childProcess.killed) {
+        console.log(chalk.yellow("Stopping MCP server..."));
+        console.log(
+          `\n\n${chalk.white(
+            "Thanks so much for using Smithery!"
+          )}\n🚀 One-click cloud deploy: ${chalk.blue.underline(
+            "https://smithery.ai/new"
+          )}\n\n`
+        );
+        childProcess.kill("SIGTERM");
 
-				// Force kill after 5 seconds
-				setTimeout(() => {
-					if (childProcess && !childProcess.killed) {
-						childProcess.kill("SIGKILL")
-					}
-				}, 5000)
-			}
+        // Force kill after 5 seconds
+        setTimeout(() => {
+          if (childProcess && !childProcess.killed) {
+            childProcess.kill("SIGKILL");
+          }
+        }, 5000);
+      }
 
-			process.exit(0)
-		}
+      process.exit(0);
+    };
 
-		// Set up signal handlers
-		process.on("SIGINT", cleanup)
-		process.on("SIGTERM", cleanup)
+    // Set up signal handlers
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
 
-		// Keep the process alive
-		await new Promise<void>(() => {})
-	} catch (error) {
-		console.error(chalk.red("❌ Dev server failed:"), error)
-		process.exit(1)
-	}
+    // Keep the process alive
+    await new Promise<void>(() => {});
+  } catch (error) {
+    console.error(chalk.red("❌ Dev server failed:"), error);
+    process.exit(1);
+  }
 }

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -20,7 +20,7 @@ import ora from "ora"
 import { resolveServer, ResolveServerSource } from "../registry"
 import { chooseConnection, collectConfigValues } from "../utils/config"
 import { getRuntimeEnvironment } from "../utils/runtime.js"
-import { verbose } from "../logger"
+import { verbose, debug } from "../logger"
 
 async function createClient() {
 	const client = new Client(
@@ -30,7 +30,7 @@ async function createClient() {
 	client.setNotificationHandler(
 		LoggingMessageNotificationSchema,
 		(notification) => {
-			console.debug("[server log]:", notification.params.data)
+			debug(`[server log]: ${notification.params.data}`)
 		},
 	)
 	return client
@@ -83,7 +83,9 @@ async function connectServer(transport: any) {
 		const primitives = await listPrimitives(client)
 
 		spinner.succeed(
-			`Connected, server capabilities: ${Object.keys(client.getServerCapabilities() || {}).join(", ")}`,
+			`Connected, server capabilities: ${Object.keys(
+				client.getServerCapabilities() || {},
+			).join(", ")}`,
 		)
 
 		// Setup exit handlers
@@ -172,7 +174,9 @@ async function connectServer(transport: any) {
 		}
 	} catch (error) {
 		spinner.fail(
-			`Failed to connect to server: ${error instanceof Error ? error.message : String(error)}`,
+			`Failed to connect to server: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
 		)
 
 		// Clean up the client if it exists
@@ -257,13 +261,19 @@ export async function inspectServer(
 		// Collect configuration values if needed
 		const configValues = await collectConfigValues(connection)
 		verbose(
-			`Collected Configuration Structure: ${JSON.stringify(Object.keys(configValues), null, 2)}`,
+			`Collected Configuration Structure: ${JSON.stringify(
+				Object.keys(configValues),
+				null,
+				2,
+			)}`,
 		)
 
 		// Get runtime environment
 		const runtimeEnv = getRuntimeEnvironment({})
 		verbose(
-			`Runtime environment initialized with ${Object.keys(runtimeEnv).length} variables`,
+			`Runtime environment initialized with ${
+				Object.keys(runtimeEnv).length
+			} variables`,
 		)
 
 		// Create appropriate transport with environment variables

--- a/src/commands/playground.ts
+++ b/src/commands/playground.ts
@@ -2,6 +2,7 @@ import chalk from "chalk"
 import type { ChildProcess } from "node:child_process"
 import { startSubprocess } from "../lib/subprocess"
 import { setupTunnelAndPlayground } from "../lib/dev-lifecycle"
+import { debug } from "../logger"
 
 export async function playground(options: {
 	port?: string
@@ -35,9 +36,9 @@ export async function playground(options: {
 			// Close tunnel
 			try {
 				await listener.close()
-				console.log(chalk.green("Tunnel closed"))
+				debug(chalk.green("Tunnel closed"))
 			} catch (error) {
-				console.log(chalk.yellow("Tunnel already closed"))
+				debug(chalk.yellow("Tunnel already closed"))
 			}
 
 			// Kill child process if it exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ const program = new Command()
 program
 	.name("smithery")
 	.description("Smithery CLI - Manage and run MCP servers")
-	.version("1.0.0")
 	.option("--verbose", "Show detailed logs")
 	.hook("preAction", (thisCommand, actionCommand) => {
 		// Set verbose mode if flag is present
@@ -51,7 +50,9 @@ program
 		if (!VALID_CLIENTS.includes(options.client as ValidClient)) {
 			console.error(
 				chalk.yellow(
-					`Invalid client "${options.client}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
+					`Invalid client "${
+						options.client
+					}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
 				),
 			)
 			process.exit(1)
@@ -101,7 +102,9 @@ program
 		if (!VALID_CLIENTS.includes(options.client as ValidClient)) {
 			console.error(
 				chalk.yellow(
-					`Invalid client "${options.client}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
+					`Invalid client "${
+						options.client
+					}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
 				),
 			)
 			process.exit(1)
@@ -239,7 +242,9 @@ program
 			if (!options.client) {
 				console.error(
 					chalk.yellow(
-						`Please specify a client using --client. Valid options are: ${VALID_CLIENTS.join(", ")}`,
+						`Please specify a client using --client. Valid options are: ${VALID_CLIENTS.join(
+							", ",
+						)}`,
 					),
 				)
 				process.exit(1)
@@ -248,7 +253,9 @@ program
 			if (!VALID_CLIENTS.includes(options.client as ValidClient)) {
 				console.error(
 					chalk.yellow(
-						`Invalid client "${options.client}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
+						`Invalid client "${
+							options.client
+						}". Valid options are: ${VALID_CLIENTS.join(", ")}`,
 					),
 				)
 				process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { playground } from "./commands/playground"
 import { run } from "./commands/run/index"
 import { uninstallServer } from "./commands/uninstall"
 import { type ValidClient, VALID_CLIENTS } from "./constants"
-import { setVerbose } from "./logger"
+import { setVerbose, setDebug } from "./logger"
 import type { ServerConfig } from "./types/registry"
 import { ensureApiKey, promptForApiKey } from "./utils/runtime"
 import { build } from "./commands/build"
@@ -23,11 +23,15 @@ program
 	.name("smithery")
 	.description("Smithery CLI - Manage and run MCP servers")
 	.option("--verbose", "Show detailed logs")
+	.option("--debug", "Show debug logs")
 	.hook("preAction", (thisCommand, actionCommand) => {
 		// Set verbose mode if flag is present
 		const opts = thisCommand.opts()
 		if (opts.verbose) {
 			setVerbose(true)
+		}
+		if (opts.debug) {
+			setDebug(true)
 		}
 	})
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,12 +166,14 @@ program
 	.option("--port <port>", "Port to run the server on (default: 8181)")
 	.option("--key <apikey>", "Provide an API key")
 	.option("--no-open", "Don't automatically open the playground")
+	.option("--prompt <prompt>", "Initial message to start the playground with")
 	.action(async (entryFile, options) => {
 		await dev({
 			entryFile,
 			port: options.port,
 			key: options.key,
 			open: options.open,
+			initialMessage: options.prompt,
 		})
 	})
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -4,10 +4,13 @@ import { promisify } from "node:util"
 
 const execAsync = promisify(exec)
 
-export async function openPlayground(tunnelUrl: string): Promise<void> {
+export async function openPlayground(
+	tunnelUrl: string,
+	initialMessage: string,
+): Promise<void> {
 	const playgroundUrl = `https://smithery.ai/playground?mcp=${encodeURIComponent(
 		`${tunnelUrl}/mcp`,
-	)}`
+	)}&prompt=${encodeURIComponent(initialMessage)}`
 
 	console.log(chalk.cyan(`🔗 Playground: ${playgroundUrl}`))
 

--- a/src/lib/dev-lifecycle.ts
+++ b/src/lib/dev-lifecycle.ts
@@ -6,6 +6,7 @@ export async function setupTunnelAndPlayground(
 	port: string,
 	apiKey: string,
 	autoOpen = true,
+	initialMessage = "Say hello to the world!",
 ): Promise<{ listener: any; url: string }> {
 	const { listener, url } = await startTunnel(port, apiKey)
 

--- a/src/lib/dev-lifecycle.ts
+++ b/src/lib/dev-lifecycle.ts
@@ -11,7 +11,7 @@ export async function setupTunnelAndPlayground(
 	const { listener, url } = await startTunnel(port, apiKey)
 
 	if (autoOpen) {
-		await openPlayground(url)
+		await openPlayground(`${url}&prompt=${encodeURIComponent(initialMessage)}`)
 	}
 
 	console.log(chalk.gray("Press Ctrl+C to stop the dev server"))

--- a/src/lib/dev-lifecycle.ts
+++ b/src/lib/dev-lifecycle.ts
@@ -11,7 +11,7 @@ export async function setupTunnelAndPlayground(
 	const { listener, url } = await startTunnel(port, apiKey)
 
 	if (autoOpen) {
-		await openPlayground(`${url}&prompt=${encodeURIComponent(initialMessage)}`)
+		await openPlayground(url, initialMessage)
 	}
 
 	console.log(chalk.gray("Press Ctrl+C to stop the dev server"))

--- a/src/lib/tunnel.ts
+++ b/src/lib/tunnel.ts
@@ -1,5 +1,6 @@
 import ngrok from "@ngrok/ngrok"
 import chalk from "chalk"
+import { debug } from "../logger"
 
 export async function getTemporaryTunnelToken(apiKey: string): Promise<{
 	authtoken: string
@@ -27,7 +28,9 @@ export async function getTemporaryTunnelToken(apiKey: string): Promise<{
 		return await response.json()
 	} catch (error) {
 		throw new Error(
-			`Failed to connect to Smithery API: ${error instanceof Error ? error.message : error}`,
+			`Failed to connect to Smithery API: ${
+				error instanceof Error ? error.message : error
+			}`,
 		)
 	}
 }
@@ -60,10 +63,10 @@ export async function startTunnel(
 	listener: any
 	url: string
 }> {
-	console.log(chalk.blue(`🚀 Starting tunnel for localhost:${port}...`))
+	debug(chalk.blue(`🚀 Starting tunnel for localhost:${port}...`))
 
 	// Get temporary token from Smithery backend
-	console.log(chalk.gray("Getting tunnel credentials..."))
+	debug(chalk.gray("Getting tunnel credentials..."))
 	const { authtoken, domain } = await getTemporaryTunnelToken(apiKey)
 
 	// Start tunnel using ngrok SDK with temporary token

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,24 @@
 import chalk from "chalk"
 
 let isVerbose = false
+let isDebug = false
 
 export function setVerbose(value: boolean): void {
 	isVerbose = value
 }
 
+export function setDebug(value: boolean): void {
+	isDebug = value
+}
+
 export function verbose(message: string): void {
 	if (isVerbose) {
 		console.log(chalk.gray(`[verbose] ${message}`))
+	}
+}
+
+export function debug(message: string): void {
+	if (isDebug) {
+		console.debug(chalk.blue(`[debug] ${message}`))
 	}
 }


### PR DESCRIPTION
- Reduced noisy logs and made them debug logs (tunnel started/stopped etc.)
- User can run `npx @smithery/cli dev --debug` to enable debug logs
- User can run `npx @smithery/cli dev --prompt "say hello"` to set the initial playground message (URL query param `prompt`)
- Added a "one-click deploy: https://smithery.ai/new" log

Final output:
<img width="820" alt="image" src="https://github.com/user-attachments/assets/c3047592-42e1-4f33-940c-5aea914deca2" />
