### PR TITLE
Align the binary name with the package's

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test": "jest"
 	},
 	"bin": {
-		"cli": "dist/index.js"
+		"smithery": "dist/index.js"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.15.0",


### PR DESCRIPTION
### What's added in this PR?
I noticed the name of the binary is `cli`, which is very generic. I'm updating it to be `smithery` to align with the name of the package and the product.
