### PR TITLE
fix: pnpm build failures by marking bootstrap dependencies as external

### DIFF
--- a/src/runtime/shttp-bootstrap.ts
+++ b/src/runtime/shttp-bootstrap.ts
@@ -114,8 +114,8 @@ async function startMcpServer() {
 		} else {
 			throw new Error(
 				"No valid server export found. Please export:\n" +
-				"- export default function({ sessionId, config }) { ... } (stateful)\n" +
-				"- export default function({ config }) { ... } (stateless)",
+					"- export default function({ sessionId, config }) { ... } (stateful)\n" +
+					"- export default function({ config }) { ... } (stateless)",
 			)
 		}
 


### PR DESCRIPTION
Fixes build failures with pnpm where esbuild couldn't resolve bootstrap dependencies (chalk, cors, express, etc.) due to pnpm's non-hoisted node_modules structure.

Changes:
- Mark bootstrap dependencies as external in esbuild config
- Merge custom config externals with bootstrap externals

This doesn't affect npm/bun builds - dependencies are still resolved at runtime via Node's module resolution.