### PR TITLE
revert: remove bootstrap externals approach, use pnpm hoisting instead

### DIFF
--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -159,20 +159,6 @@ async function esbuildServer(
 		},
 	})
 
-	// Dependencies used by bootstrap code that should be external
-	// These are provided by @smithery/cli or @smithery/sdk and should not be bundled
-	const bootstrapExternals = [
-		"chalk",
-		"cors",
-		"express",
-		"lodash",
-		"uuidv7",
-		"zod-to-json-schema",
-		"@smithery/sdk",
-		"@modelcontextprotocol/sdk",
-		"zod",
-	]
-
 	// Common build options
 	const shouldMinify = options.minify ?? true // Default to minified
 	const commonOptions: esbuild.BuildOptions = {
@@ -183,7 +169,6 @@ async function esbuildServer(
 		minify: shouldMinify,
 		sourcemap: shouldMinify ? false : "inline",
 		format: "cjs",
-		external: bootstrapExternals,
 	}
 
 	let buildConfig: esbuild.BuildOptions
@@ -201,14 +186,6 @@ async function esbuildServer(
 
 	// Load custom config
 	const customConfig = await loadCustomConfig(options.configFile)
-	// Merge externals arrays if custom config provides one
-	if (customConfig.external && Array.isArray(customConfig.external)) {
-		buildConfig.external = [
-			...bootstrapExternals,
-			...(customConfig.external as string[]),
-		]
-		delete customConfig.external // Remove from customConfig to avoid overriding
-	}
 	buildConfig = { ...buildConfig, ...(customConfig as esbuild.BuildOptions) }
 
 	if (options.watch && options.onRebuild) {


### PR DESCRIPTION
Reverts the bootstrap externals approach from #487. The pnpm build issue is now resolved via dependency hoisting in pnpm configuration instead of marking dependencies as external in esbuild.

Removes:
- bootstrapExternals array
- external property from build config
- custom config externals merging logic