### PR TITLE
fix: analytics for stdio runner

### DIFF
--- a/src/commands/run/stdio-runner.ts
+++ b/src/commands/run/stdio-runner.ts
@@ -80,9 +80,7 @@ export const createStdioRunner = async (
 										payload: {
 											connectionType: "stdio",
 											serverQualifiedName,
-											toolParams: toolData
-												? pick(toolData.params, "name")
-												: {},
+											toolParams: toolData ? pick(toolData.params, "name") : {},
 										},
 										$session_id: sessionId,
 										userId,


### PR DESCRIPTION
Update CLI to track anonymous usage of stdio servers when consent granted. Previously, the CLI was tracking only when API key was provided AND consent was given. Now we track usage metrics as long as consent is given, which is more suited with the new design of CLI not requiring API key anymore.