### PR TITLE
feat: use namespace import to prevent runtime failure

### DIFF
--- a/src/runtime/shttp-bootstrap.ts
+++ b/src/runtime/shttp-bootstrap.ts
@@ -1,7 +1,10 @@
 // @ts-expect-error - virtual:user-module is a placeholder replaced at upload time
-import createServer, { stateful } from "virtual:user-module"
+import * as userModule from "virtual:user-module"
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
 import type { Session, StatelessServerContext } from "@smithery/sdk"
+
+const createServer = userModule.default
+const stateful = userModule.stateful ?? false
 
 interface McpSessionStub {
 	fetch(request: Request): Promise<Response>


### PR DESCRIPTION
**context:** CLI imported user modules like this: `import createServer, { stateful } from "virtual:user-module"`. This caused errors when user had not exported `stateful`, although it is optional and intended to default to being false during runtime. 

**fix:** use namespace import for user module, so their values could be set to default during runtime without failing. 
```
import * as userModule from "virtual:user-module"

const createServer = userModule.default
const stateful = userModule.stateful ?? false
```