### PR TITLE
skip config prompts for remote OAuth servers

### DIFF
--- a/src/utils/install/server-config.ts
+++ b/src/utils/install/server-config.ts
@@ -87,7 +87,7 @@ function createStdioConfig(qualifiedName: string): ConfiguredServer {
  * @param server - Server details
  * @returns The configuration type to use
  */
-function determineConfigType(client: string, server: Server): ConfigType {
+export function determineConfigType(client: string, server: Server): ConfigType {
 	const clientConfig = getClientConfiguration(client)
 
 	// Check if server supports HTTP


### PR DESCRIPTION
## Summary                                                                    
   - Skip `resolveUserConfig()` and keychain save when installing remote servers for OAuth-supporting clients                                                
   - The browser OAuth flow already prompts for config values, making CLI prompts redundant                                                                  
   - Export `determineConfigType` from server-config.ts for reuse in install.ts       