### PR TITLE
3.3.4 - Fix qualified name parsing for simple server names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.3.3] - 2025-01-26
+## [3.3.4] - 2025-01-26
 
 ### Fixed
-- Fixed qualified name parsing - simple names like `linear` now consistently resolve with `namespace="linear"` instead of empty namespace
+- Fixed qualified name parsing - simple names like `linear` now correctly resolve with `serverName="linear"` and empty namespace
+
+## [3.3.3] - 2025-01-26
 
 ### Changed
 - Refactored `resolveServer()` to accept `{ namespace, serverName }` instead of qualified name string - callers now use centralized `parseQualifiedName()` utility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smithery/cli",
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"type": "module",
 	"private": false,
 	"homepage": "https://smithery.ai/",

--- a/src/lib/__tests__/registry.test.ts
+++ b/src/lib/__tests__/registry.test.ts
@@ -52,10 +52,16 @@ describe("resolveServer", () => {
 		)
 	})
 
-	test("calls SDK with namespace and serverName", async () => {
+	test("calls SDK with namespace and serverName for scoped name", async () => {
 		await resolveServer(parseQualifiedName("@foo/bar"))
 
 		expect(mockGet).toHaveBeenCalledWith("bar", { namespace: "foo" })
+	})
+
+	test("calls SDK with empty namespace for simple name", async () => {
+		await resolveServer(parseQualifiedName("linear"))
+
+		expect(mockGet).toHaveBeenCalledWith("linear", { namespace: "" })
 	})
 
 	test("returns server and first connection", async () => {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -9,7 +9,6 @@ import fetch from "cross-fetch"
 import { config as dotenvConfig } from "dotenv"
 import { ANALYTICS_ENDPOINT } from "../constants"
 import { getSessionId } from "../utils/analytics"
-import type { Namespace } from "../utils/qualified-name"
 import { getUserId } from "../utils/smithery-settings"
 import { verbose } from "./logger"
 
@@ -44,7 +43,7 @@ export interface ResolvedServer {
 }
 
 export interface ResolveServerParams {
-	namespace: Namespace
+	namespace: string
 	serverName: string
 }
 

--- a/src/utils/__tests__/qualified-name.test.ts
+++ b/src/utils/__tests__/qualified-name.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test } from "vitest"
-import { isValidNamespace, parseQualifiedName } from "../qualified-name"
+import { parseQualifiedName } from "../qualified-name"
 
 describe("parseQualifiedName", () => {
 	test.each([
 		// [input, expectedNamespace, expectedServerName]
-		["linear", "linear", ""],
-		["myorg", "myorg", ""],
-		["@linear", "linear", ""],
+		["linear", "", "linear"],
+		["myorg", "", "myorg"],
 		["@foo/bar", "foo", "bar"],
 		["foo/bar", "foo", "bar"],
 		["@smithery/github", "smithery", "github"],
@@ -18,25 +17,9 @@ describe("parseQualifiedName", () => {
 		expect(result.serverName).toBe(expectedServerName)
 	})
 
-	test.each([
-		"",
-		"@",
-		"@/bar",
-		"/bar",
-	])('throws error for invalid input "%s" with empty namespace', (input) => {
-		expect(() => parseQualifiedName(input)).toThrow(
-			"Invalid qualified name: namespace cannot be empty",
+	test("throws error for empty input", () => {
+		expect(() => parseQualifiedName("")).toThrow(
+			"Invalid qualified name: cannot be empty",
 		)
-	})
-})
-
-describe("isValidNamespace", () => {
-	test("returns true for non-empty strings", () => {
-		expect(isValidNamespace("foo")).toBe(true)
-		expect(isValidNamespace("smithery")).toBe(true)
-	})
-
-	test("returns false for empty string", () => {
-		expect(isValidNamespace("")).toBe(false)
 	})
 })


### PR DESCRIPTION
## Summary
- Fix qualified name parsing - simple names like `linear` now correctly resolve with `serverName="linear"` and empty namespace
- This fixes the 404 error when running `smithery install linear`

## The Bug
v3.3.3 incorrectly inverted the parsing:
- `linear` was parsed as `{ namespace: "linear", serverName: "" }` ❌

## The Fix  
- `linear` now correctly parses as `{ namespace: "", serverName: "linear" }` ✅
- `@foo/bar` still correctly parses as `{ namespace: "foo", serverName: "bar" }` ✅

## Test plan
- [x] All 231 tests pass
- [x] `smithery install linear` should now work

🤖 Generated with [Claude Code](https://claude.com/claude-code)