### PR TITLE
Add post-install hint for CLI clients

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -14,7 +14,7 @@ import { verbose } from "../lib/logger"
 import { resolveServer } from "../lib/registry"
 import type { ServerConfig } from "../types/registry"
 import { checkAnalyticsConsent } from "../utils/analytics"
-import { promptForRestart } from "../utils/client"
+import { promptForRestart, showPostInstallHint } from "../utils/client"
 import { getServerName } from "../utils/install/helpers"
 import {
 	determineConfigType,
@@ -129,6 +129,7 @@ export async function installServer(
 		console.log(
 			chalk.green(`✓ ${qualifiedName} successfully installed for ${client}`),
 		)
+		showPostInstallHint(client)
 		await promptForRestart(client)
 		process.exit(0)
 	} catch (error) {

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,5 +1,6 @@
 import { exec } from "node:child_process"
 import { promisify } from "node:util"
+import chalk from "chalk"
 import inquirer from "inquirer"
 
 const execAsync = promisify(exec)
@@ -92,4 +93,19 @@ export async function promptForRestart(client?: string): Promise<boolean> {
 	}
 
 	return shouldRestart
+}
+
+export function showPostInstallHint(client: string): void {
+	const cliClients: Record<string, string> = {
+		"claude-code": "Claude Code",
+		"gemini-cli": "Gemini CLI",
+		codex: "Codex",
+	}
+
+	const label = cliClients[client]
+	if (label) {
+		console.log(
+			chalk.cyan(`ℹ You may need to restart ${label} for changes to take effect.`),
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- Add `showPostInstallHint` function that displays a restart message for CLI clients
- Show hint after successful server installation for Claude Code, Gemini CLI, and Codex
- Helps users understand they may need to restart their CLI for changes to take effect

## Test plan
- [x] Install a server with `smithery install` targeting Claude Code
- [x] Verify the hint message appears after successful installation
- [x] Verify no hint appears for non-CLI clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)