### PR TITLE
Add CI/CD workflow with parallel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
@@ -25,9 +26,40 @@ jobs:
       - run: pnpm install
       - run: pnpm test
 
-  build:
+  typecheck:
+    name: Typecheck
     runs-on: ubuntu-latest
-    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm run typecheck
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm add -D @biomejs/cli-linux-x64  # biome platform binary for linux ci
+      - run: pnpm run check
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +70,4 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm add -D @biomejs/cli-linux-x64  # biome platform binary for linux ci
       - run: pnpm run build
-      - run: pnpm run check


### PR DESCRIPTION
### What's added in this PR?

Refactored the GitHub Actions CI workflow to run test, typecheck, lint, and build jobs in parallel for faster feedback. Each job is now a separate status check on PRs, providing granular visibility into what's passing or failing.

**Key improvements:**
- Test, typecheck, lint, and build jobs run concurrently
- Removed job dependencies to enable parallel execution
- Each job is a distinct status check on PRs
- Faster overall CI feedback cycle

### What's the issues or discussion related to this PR?

This improves developer experience by providing faster CI feedback and clearer status checks for each quality gate (tests, types, linting, and builds).