### PR TITLE
feat: add skills search and install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requires Node.js 20+.
 
 ## Commands
 
-### Local Server Management
+### Servers
 
 ```bash
 smithery install <server>     # Install a server to an AI client
@@ -25,13 +25,36 @@ smithery run <server>         # Run a server locally
 
 Options: `--client <name>` to skip client selection, `--config <json>` to provide configuration.
 
+### Skills
+
+Browse and install reusable prompt-based skills from the [Smithery Skills Registry](https://smithery.ai/skills). Installation uses the [Vercel Labs skills CLI](https://github.com/vercel-labs/skills).
+
+```bash
+smithery skills search [query]           # Interactive skill search and browsing
+smithery skills install <namespace/slug> --agent <name> # Install a skill
+smithery skills install <skill> --agent <name> --global # Install globally
+smithery skills agents                   # List available agents
+```
+
+Options for `search`: `--json` for JSON output, `--limit <n>` for max results, `--namespace <ns>` to filter.
+
+### Namespaces
+
+Discover public namespaces on Smithery.
+
+```bash
+smithery namespace search [query] # Search public namespaces (requires login)
+```
+
+Options: `--limit <n>`, `--has-skills`, `--has-servers`.
+
 ### Smithery Connect (Cloud MCP)
 
 Manage cloud-hosted MCP servers via [Smithery Connect](https://smithery.ai).
 
 ```bash
 # Namespace context (auto-created on first use)
-smithery namespace list       # List namespaces
+smithery namespace list       # List your namespaces
 smithery namespace use <name> # Set current namespace
 smithery namespace show       # Show current namespace
 
@@ -58,8 +81,16 @@ smithery playground           # Open interactive testing UI
 ## Examples
 
 ```bash
-# Install a server
-smithery install exa --client claude --config '{"exaApiKey":"xxx"}'
+# Install a server locally
+smithery install exa --client cursor
+
+# Browse and install skills
+smithery skills search "frontend" --json
+smithery skills search --namespace anthropics --json  # Filter by namespace
+smithery skills install anthropics/frontend-design --agent claude-code
+
+# Discover namespaces
+smithery namespace search --has-skills  # Find namespaces with skills
 
 # Cloud MCP workflow
 smithery connect add https://server.smithery.ai/github
@@ -75,7 +106,7 @@ smithery build --out dist/server.cjs
 
 ```bash
 git clone https://github.com/smithery-ai/cli
-cd cli && npm install && npm run build
+cd cli && pnpm install && pnpm run build
 npx . --help
 ```
 

--- a/src/commands/connect/api.ts
+++ b/src/commands/connect/api.ts
@@ -1,13 +1,13 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import type { Tool } from "@modelcontextprotocol/sdk/types.js"
+import {
+	type CreateConnectionOptions,
+	createConnection as createSmitheryConnection,
+} from "@smithery/api/mcp"
 import type {
 	Connection,
 	ConnectionsListResponse,
 } from "@smithery/api/resources/experimental/connect/connections.js"
-import {
-	createConnection as createSmitheryConnection,
-	type CreateConnectionOptions,
-} from "@smithery/api/mcp"
 import { createSmitheryClient } from "../../lib/smithery-client"
 import {
 	getNamespace as getStoredNamespace,
@@ -70,7 +70,8 @@ export class ConnectSession {
 		// Use createConnection from @smithery/api/mcp - skips handshake for faster connections
 		// Cast client to work around TypeScript CJS/ESM type incompatibility
 		const { transport } = await createSmitheryConnection({
-			client: this.smitheryClient as unknown as CreateConnectionOptions["client"],
+			client: this
+				.smitheryClient as unknown as CreateConnectionOptions["client"],
 			namespace: this.namespace,
 			connectionId,
 		})

--- a/src/commands/namespace/index.ts
+++ b/src/commands/namespace/index.ts
@@ -1,4 +1,5 @@
 export { createNamespace } from "./create"
 export { listNamespaces } from "./list"
+export { searchPublicNamespaces } from "./search"
 export { showNamespace } from "./show"
 export { useNamespace } from "./use"

--- a/src/commands/namespace/search.ts
+++ b/src/commands/namespace/search.ts
@@ -1,0 +1,89 @@
+import type { Smithery } from "@smithery/api/client.js"
+import chalk from "chalk"
+import { createSmitheryClient } from "../../lib/smithery-client"
+
+export interface NamespaceSearchOptions {
+	limit?: number
+	hasSkills?: boolean
+	hasServers?: boolean
+}
+
+/**
+ * Search public namespaces
+ * @param query - Optional search query (prefix match on name)
+ * @param options - Search options
+ */
+export async function searchPublicNamespaces(
+	query?: string,
+	options: NamespaceSearchOptions = {},
+): Promise<void> {
+	const { limit = 20, hasSkills, hasServers } = options
+
+	let client: Smithery
+	try {
+		client = await createSmitheryClient()
+	} catch {
+		console.error(chalk.red("Error: Not logged in."))
+		console.error(chalk.dim("Run 'smithery login' to authenticate."))
+		process.exit(1)
+	}
+
+	// Build query params
+	const queryParams: {
+		q?: string
+		pageSize: number
+		hasSkills?: "1" | "0"
+		hasServers?: "1" | "0"
+	} = {
+		pageSize: limit,
+	}
+
+	if (query) {
+		queryParams.q = query
+	}
+	if (hasSkills !== undefined) {
+		queryParams.hasSkills = hasSkills ? "1" : "0"
+	}
+	if (hasServers !== undefined) {
+		queryParams.hasServers = hasServers ? "1" : "0"
+	}
+
+	try {
+		const ora = (await import("ora")).default
+		const searchMsg = query
+			? `Searching namespaces for "${query}"...`
+			: "Listing public namespaces..."
+		const spinner = ora(searchMsg).start()
+
+		const response = await client.namespaces.list(queryParams)
+		const namespaces = response.namespaces
+
+		if (namespaces.length === 0) {
+			spinner.fail(
+				query ? `No namespaces found for "${query}"` : "No namespaces found",
+			)
+			return
+		}
+
+		spinner.succeed(
+			`Found ${namespaces.length} namespace${namespaces.length === 1 ? "" : "s"}:`,
+		)
+		console.log()
+
+		for (const ns of namespaces) {
+			console.log(`  ${chalk.cyan(ns.name)}`)
+		}
+		console.log()
+		console.log(
+			chalk.dim(
+				`Use 'smithery skills search --namespace <name>' to browse skills in a namespace`,
+			),
+		)
+	} catch (error) {
+		console.error(
+			chalk.red("Error searching namespaces:"),
+			error instanceof Error ? error.message : String(error),
+		)
+		process.exit(1)
+	}
+}

--- a/src/commands/skills/index.ts
+++ b/src/commands/skills/index.ts
@@ -1,2 +1,2 @@
-export { searchSkills } from "./search"
 export { installSkill } from "./install"
+export { searchSkills } from "./search"

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -1,0 +1,48 @@
+/**
+ * Available agents for the Vercel Labs skills CLI
+ * https://github.com/vercel-labs/skills
+ *
+ * These are the agent identifiers used with `npx skills add --agent <name>`
+ */
+
+export const SKILL_AGENTS = [
+	"claude-code",
+	"cursor",
+	"codex",
+	"windsurf",
+	"cline",
+	"roo-code",
+	"goose",
+	"continue",
+	"github-copilot",
+	"opencode",
+	"openhands",
+	"junie",
+	"codebuddy",
+	"command-code",
+	"amp",
+	"antigravity",
+	"augment",
+	"crush",
+	"droid",
+	"gemini-cli",
+	"kilo-code",
+	"kiro-cli",
+	"kode",
+	"mcpjam",
+	"mistral-vibe",
+	"mux",
+	"pi",
+	"qoder",
+	"qwen-code",
+	"replit",
+	"trae",
+	"trae-cn",
+	"zencoder",
+	"neovate",
+	"pochi",
+	"adal",
+	"iflow-cli",
+] as const
+
+export type SkillAgent = (typeof SKILL_AGENTS)[number]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { createServer } from "node:http"
 import chalk from "chalk"
 import { Command } from "commander"
+import { SKILL_AGENTS } from "./config/agents"
 import { VALID_CLIENTS, type ValidClient } from "./config/clients"
 import { DEFAULT_PORT } from "./constants"
 import { setDebug, setVerbose } from "./lib/logger"
@@ -573,6 +574,21 @@ namespace
 		await createNamespace(name)
 	})
 
+namespace
+	.command("search [query]")
+	.description("Search public namespaces (requires login)")
+	.option("--limit <number>", "Maximum number of results to show", "20")
+	.option("--has-skills", "Only show namespaces with skills")
+	.option("--has-servers", "Only show namespaces with servers")
+	.action(async (query, options) => {
+		const { searchPublicNamespaces } = await import("./commands/namespace")
+		await searchPublicNamespaces(query, {
+			limit: Number.parseInt(options.limit, 10),
+			hasSkills: options.hasSkills,
+			hasServers: options.hasServers,
+		})
+	})
+
 // Connect command - manage MCP server connections and tools
 const connect = program
 	.command("connect")
@@ -656,26 +672,53 @@ const skills = program
 	.description("Search and install Smithery skills")
 
 skills
-	.command("search [query]")
-	.description("Search for skills in the Smithery registry")
-	.option("--dump", "Print search results without interactive selection")
-	.option("--limit <number>", "Maximum number of results to show", "10")
-	.action(async (query, options) => {
-		const selectedSkill = await searchSkills(query, {
-			dump: options.dump,
-			limit: Number.parseInt(options.limit, 10),
-		})
-		if (selectedSkill) {
-			// User selected "Install this skill"
-			await installSkill(`@${selectedSkill.namespace}/${selectedSkill.slug}`)
+	.command("agents")
+	.description("List available agents for skill installation")
+	.action(() => {
+		console.log(chalk.bold("Available agents:"))
+		console.log()
+		for (const agent of SKILL_AGENTS) {
+			console.log(`  ${agent}`)
 		}
+		console.log()
+		console.log(
+			chalk.dim("See https://github.com/vercel-labs/skills for more info"),
+		)
 	})
 
 skills
-	.command("install [skill]")
-	.description("Install a skill (runs npx skills add)")
-	.action(async (skill) => {
-		await installSkill(skill)
+	.command("search [query]")
+	.description("Search for skills in the Smithery registry")
+	.option(
+		"--json",
+		"Print search results as JSON without interactive selection",
+	)
+	.option("--limit <number>", "Maximum number of results to show", "10")
+	.option("--namespace <namespace>", "Filter by namespace")
+	.action(async (query, options) => {
+		const { searchSkills } = await import("./commands/skills")
+		await searchSkills(query, {
+			json: options.json,
+			limit: Number.parseInt(options.limit, 10),
+			namespace: options.namespace,
+		})
+	})
+
+// Uses the Vercel Labs skills CLI: https://github.com/vercel-labs/skills
+skills
+	.command("install <skill>")
+	.description("Install a skill (via github.com/vercel-labs/skills)")
+	.requiredOption(
+		"-a, --agent <name>",
+		`Target agent (${SKILL_AGENTS.slice(0, 5).join(", ")}, ...)`,
+	)
+	.option(
+		"-g, --global",
+		"Install globally (user-level) instead of project-level",
+	)
+	.action(async (skill, options) => {
+		const { installSkill } = await import("./commands/skills")
+		await installSkill(skill, options.agent, { global: options.global })
 	})
 
 // Parse arguments and run


### PR DESCRIPTION
## Summary

Implements interactive skill search and installation commands for the Smithery CLI.

## Commands

### `smithery skills search [query]`

Search for skills in the Smithery registry.

**Options:**
- `--dump` - Print search results without interactive selection (requires query)
- `--limit <number>` - Maximum number of results to show (default: 10)

**Examples:**
```bash
# Interactive search
smithery skills search

# Search with query
smithery skills search "git"

# Non-interactive dump of results
smithery skills search "git" --dump

# Limit results
smithery skills search "git" --dump --limit 5
```

**Interactive features:**
- Autocomplete filtering of results
- View skill details (description, categories, usage stats)
- Install directly from search results

### `smithery skills install [skill]`

Install a skill using the skills CLI (skills.sh).

**Arguments:**
- `skill` - Optional skill identifier (`@namespace/slug` or URL)

**Examples:**
```bash
# Interactive search and install
smithery skills install

# Install by qualified name
smithery skills install @anthropic/commit

# Install by URL
smithery skills install https://github.com/anthropics/claude-code-skill
```

**Features:**
- Hands off to skills CLI for interactive input and logging
- Supports both `@namespace/slug` format and direct URLs
- Falls back to interactive search if no skill specified

## Related

Addresses SMI-1366 to add a `skill` subcommand for searching and installing skills.