### PR TITLE
fix: use npm OIDC for tokenless publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
           ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Use npm 11.6.2+ for OIDC provenance support
+          npm install -g npm@11.6.2
+          npm publish --provenance --access public


### PR DESCRIPTION
### What's added in this PR?

Switches npm publishing from token-based auth to OIDC (OpenID Connect) for tokenless publishing.

- Uses npm 11.6.2+ which supports OIDC provenance
- Removes `NPM_TOKEN` dependency - GitHub Actions OIDC handles authentication

### What's the issues or discussion related to this PR?

The previous publish workflow failed with `Access token expired or revoked` because the NPM_TOKEN secret was invalid/expired.

OIDC publishing is more secure and doesn't require managing npm tokens.

### Required: npm configuration

After merging, configure npm to trust this workflow:
1. Go to https://www.npmjs.com/package/@smithery/cli/access
2. Under "Publishing access" → Configure GitHub Actions
3. Add workflow: `.github/workflows/publish.yml`