### PR TITLE
fix: remove registry-url to allow OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
### What's added in this PR?

Removes `registry-url` from `actions/setup-node` to allow npm OIDC authentication to work properly.

The `registry-url` option creates an `.npmrc` that expects `NODE_AUTH_TOKEN`, which interferes with OIDC authentication flow.

### What's the issues or discussion related to this PR?

Previous publish attempts failed with "Access token expired or revoked" because the setup-node action was creating an `.npmrc` that expected token-based auth, overriding OIDC.