### PR TITLE
fix: use pnpm publish with local npm for OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Publish to npm
         run: |
-          # Use npm 11.6.2+ for OIDC provenance support
-          npm install -g npm@11.6.2
-          npm publish --provenance --access public
+          # Install OIDC-compatible npm version locally
+          npm install --prefix ./oidc npm@11.6.2
+          # Use pnpm publish with the local npm binary for OIDC auth
+          pnpm publish --npm-path "$(pwd)/oidc/node_modules/.bin/npm" --no-git-checks --provenance --access public


### PR DESCRIPTION
### What's added in this PR?

Uses pnpm's `--npm-path` option to ensure the OIDC-compatible npm version is used for publishing. This matches the approach used by Stainless SDKs.

Changes:
- Install npm 11.6.2 locally instead of globally
- Use `pnpm publish --npm-path` to invoke the local npm binary

### What's the issues or discussion related to this PR?

Previous attempts failed with `ENEEDAUTH` because the global npm install wasn't being used properly for OIDC authentication.