### PR TITLE
fix: remove .npmrc that interferes with OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,12 @@ jobs:
 
       - name: Publish to npm
         run: |
+          # Remove .npmrc created by setup-node (interferes with OIDC)
+          rm -f "$NPM_CONFIG_USERCONFIG"
+          unset NPM_CONFIG_USERCONFIG
+
           # Install OIDC-compatible npm version locally
           npm install --prefix ./oidc npm@11.6.2
+
           # Use pnpm publish with the local npm binary for OIDC auth
           pnpm publish --npm-path "$(pwd)/oidc/node_modules/.bin/npm" --no-git-checks --provenance --access public


### PR DESCRIPTION
### What's added in this PR?

Removes the `.npmrc` file created by `actions/setup-node` before publishing. This file contains an empty `NODE_AUTH_TOKEN` reference that prevents npm OIDC from working.

### What's the issues or discussion related to this PR?

The publish workflow was failing with `ENEEDAUTH` because `actions/setup-node` creates an `.npmrc` at `NPM_CONFIG_USERCONFIG` that references `NODE_AUTH_TOKEN`. Since we're using OIDC (not token auth), this empty token reference causes npm to fail.