### PR TITLE
fix: allow SDK client to work without API key

### DIFF
--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -20,7 +20,9 @@ dotenvConfig({ quiet: true })
  * Base URL and API key are handled by SDK via env vars.
  */
 const createSDKOptions = (apiKey?: string): ClientOptions => ({
-	apiKey,
+	// Pass empty string when no API key - SDK requires non-undefined value
+	// but API endpoints may still work without authentication
+	apiKey: apiKey ?? "",
 	timeout: 5000,
 	maxRetries: 2,
 })


### PR DESCRIPTION
## Summary
- Pass empty string instead of undefined when no API key is available
- The SDK constructor throws if `apiKey` is `undefined`, but API endpoints may still work without authentication
- This fixes the install command failing with "The SMITHERY_API_KEY environment variable is missing or empty" error

## Test plan
- [x] All existing tests pass
- [ ] Manual test: `smithery install cameroncooke/xcodebuildmcp` without API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)