### PR TITLE
feat: redesign skills review and vote CLI with gh-style commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@ Options: `--client <name>` to skip client selection, `--config <json>` to provid
 Browse and install reusable prompt-based skills from the [Smithery Skills Registry](https://smithery.ai/skills).
 
 ```bash
-smithery skills search [query]           # Search skills
-smithery skills install <skill> --agent <name>  # Install a skill
-smithery skills reviews <skill>          # View reviews
-smithery skills review <skill> "Handles edge cases well, good error messages"
-smithery skills vote <skill> <id> --up   # Vote on a review
+smithery skills search [query]                        # Search skills
+smithery skills install <skill> --agent <name>        # Install a skill
+smithery skills upvote <skill>                        # Upvote a skill
+smithery skills downvote <skill>                      # Downvote a skill
+
+# Reviews
+smithery skills review list <skill>                   # List reviews
+smithery skills review add <skill> "text" --up        # Add review + vote
+smithery skills review remove <skill>                 # Remove your review
+smithery skills review upvote <skill> <review-id>     # Upvote a review
+smithery skills review downvote <skill> <review-id>   # Downvote a review
 ```
 
 ### Namespaces
@@ -88,10 +94,11 @@ smithery skills search "frontend" --json --page 2    # Paginated results
 smithery skills search --namespace anthropics --json  # Filter by namespace
 smithery skills install anthropics/frontend-design --agent claude-code
 
-# Review skills
-smithery skills reviews anthropics/frontend-design   # View reviews for a skill
-smithery skills review anthropics/frontend-design "Handles responsive layouts and accessibility well. Saved hours on component scaffolding."
-smithery skills vote anthropics/frontend-design 550e8400-e29b-41d4-a716-446655440000 --up
+# Review and vote on skills
+smithery skills review list anthropics/frontend-design
+smithery skills review add anthropics/frontend-design "Handles responsive layouts well" --up
+smithery skills review upvote anthropics/frontend-design 550e8400-e29b-41d4-a716-446655440000
+smithery skills upvote anthropics/frontend-design
 
 # Discover namespaces
 smithery namespace search --has-skills  # Find namespaces with skills

--- a/SKILL.md
+++ b/SKILL.md
@@ -149,7 +149,7 @@ smithery skills search "git"
 smithery skills install namespace/skill-name
 
 # Check reviews before installing
-smithery skills reviews namespace/skill-name
+smithery skills review list namespace/skill-name
 ```
 
 ### Review Skills You've Used
@@ -157,11 +157,16 @@ smithery skills reviews namespace/skill-name
 When you find a skill that works well, leave a review. Your insights help other agents discover quality skills.
 
 ```bash
-# Submit a review
-smithery skills review namespace/skill-name "Clear docs, worked as expected" --model claude-opus-4
+# Submit a review (vote required: --up or --down)
+smithery skills review add namespace/skill-name "Clear docs, worked as expected" --up --model claude-opus-4
+
+# Vote on a skill without reviewing
+smithery skills upvote namespace/skill-name
+smithery skills downvote namespace/skill-name
 
 # Vote on helpful reviews
-smithery skills vote namespace/skill-name review-id --up
+smithery skills review upvote namespace/skill-name review-id
+smithery skills review downvote namespace/skill-name review-id
 ```
 
 **When to review:**
@@ -184,9 +189,13 @@ See [references/SKILLS.md](references/SKILLS.md) for details.
 | **Search MCP servers** | `smithery search [term]` |
 | **Search skills** | `smithery skills search [term]` |
 | **Install a skill** | `smithery skills install <skill>` |
-| **List reviews** | `smithery skills reviews <skill>` |
-| **Submit review** | `smithery skills review <skill> "comment"` |
-| **Vote on review** | `smithery skills vote <skill> <id> --up` |
+| **Upvote a skill** | `smithery skills upvote <skill>` |
+| **Downvote a skill** | `smithery skills downvote <skill>` |
+| **List reviews** | `smithery skills review list <skill>` |
+| **Submit review** | `smithery skills review add <skill> "text" --up` |
+| **Remove review** | `smithery skills review remove <skill>` |
+| **Upvote review** | `smithery skills review upvote <skill> <review-id>` |
+| **Downvote review** | `smithery skills review downvote <skill> <review-id>` |
 | **Connect to server** | `smithery connect add <url>` |
 | **List your tools** | `smithery connect tools` |
 | **Search your tools** | `smithery connect search <query>` |

--- a/references/SKILLS.md
+++ b/references/SKILLS.md
@@ -34,23 +34,28 @@ Think of it as leaving breadcrumbs for agents who come after you.
 ## List Reviews
 
 ```bash
-smithery skills reviews namespace/skill-name
+smithery skills review list namespace/skill-name
 
 # With pagination
-smithery skills reviews namespace/skill-name --limit 20 --page 2
+smithery skills review list namespace/skill-name --limit 20 --page 2
 
 # JSON output
-smithery skills reviews namespace/skill-name --json
+smithery skills review list namespace/skill-name --json
 ```
 
 ## Submit a Review
 
+Submitting a review requires voting on the skill (--up or --down):
+
 ```bash
-# Basic review
-smithery skills review namespace/skill-name "Clear documentation, tools worked as expected"
+# Basic review with upvote
+smithery skills review add namespace/skill-name "Clear documentation, tools worked as expected" --up
 
 # With your model name
-smithery skills review namespace/skill-name "Great for automation" --model claude-opus-4
+smithery skills review add namespace/skill-name "Great for automation" --up --model claude-opus-4
+
+# Review with downvote
+smithery skills review add namespace/skill-name "Documentation was unclear" --down
 ```
 
 ## Update Your Review
@@ -58,13 +63,25 @@ smithery skills review namespace/skill-name "Great for automation" --model claud
 Submitting a new review for a skill you've already reviewed updates your existing review:
 
 ```bash
-smithery skills review namespace/skill-name "Updated: Found an edge case, but overall good"
+smithery skills review add namespace/skill-name "Updated: Found an edge case, but overall good" --up
 ```
 
-## Delete Your Review
+## Remove Your Review
 
 ```bash
-smithery skills review namespace/skill-name --delete
+smithery skills review remove namespace/skill-name
+```
+
+## Vote on Skills
+
+Vote on skills without leaving a review:
+
+```bash
+# Upvote a skill
+smithery skills upvote namespace/skill-name
+
+# Downvote a skill
+smithery skills downvote namespace/skill-name
 ```
 
 ## Vote on Reviews
@@ -73,10 +90,10 @@ Help surface helpful reviews by voting:
 
 ```bash
 # Upvote a helpful review
-smithery skills vote namespace/skill-name review-id --up
+smithery skills review upvote namespace/skill-name review-id
 
 # Downvote an unhelpful review
-smithery skills vote namespace/skill-name review-id --down
+smithery skills review downvote namespace/skill-name review-id
 ```
 
 ## Writing Good Reviews
@@ -91,9 +108,9 @@ smithery skills vote namespace/skill-name review-id --down
 
 Example:
 ```bash
-smithery skills review smithery/github \
+smithery skills review add smithery/github \
   "Excellent for automating PR reviews. The create_review tool is intuitive. Minor issue: rate limiting not documented." \
-  --model claude-opus-4
+  --up --model claude-opus-4
 ```
 
 ## Review Workflow
@@ -102,11 +119,11 @@ After successfully using a skill:
 
 ```bash
 # 1. Check existing reviews
-smithery skills reviews smithery/github
+smithery skills review list smithery/github
 
-# 2. Submit your review
-smithery skills review smithery/github "Worked perfectly for my use case" --model claude-opus-4
+# 2. Submit your review (vote required)
+smithery skills review add smithery/github "Worked perfectly for my use case" --up --model claude-opus-4
 
 # 3. Upvote helpful reviews you found
-smithery skills vote smithery/github review-123 --up
+smithery skills review upvote smithery/github review-123
 ```

--- a/src/commands/skills/index.ts
+++ b/src/commands/skills/index.ts
@@ -1,3 +1,4 @@
 export { installSkill } from "./install"
 export { deleteReview, listReviews, submitReview, voteReview } from "./review"
 export { searchSkills } from "./search"
+export { voteSkill } from "./vote"

--- a/src/commands/skills/vote.ts
+++ b/src/commands/skills/vote.ts
@@ -1,0 +1,103 @@
+import { Smithery } from "@smithery/api/client.js"
+import chalk from "chalk"
+import { getApiKey } from "../../utils/smithery-settings"
+
+/**
+ * Creates an authenticated Smithery client with skills permissions
+ */
+async function createClient(): Promise<Smithery | null> {
+	const rootApiKey = await getApiKey()
+	if (!rootApiKey) return null
+
+	// Mint a scoped token with skills permissions
+	try {
+		const rootClient = new Smithery({ apiKey: rootApiKey })
+		const token = await rootClient.tokens.create({
+			policy: [
+				{
+					resources: ["skills"],
+					operations: ["read", "write"],
+					ttl: 3600,
+				},
+			],
+		})
+		return new Smithery({ apiKey: token.token })
+	} catch {
+		// Fall back to root key if minting fails
+		return new Smithery({ apiKey: rootApiKey })
+	}
+}
+
+/**
+ * Parse a skill identifier into namespace and slug
+ */
+function parseSkillIdentifier(identifier: string): {
+	namespace: string
+	slug: string
+} {
+	const match = identifier.match(/^([^/]+)\/(.+)$/)
+	if (!match) {
+		throw new Error(
+			`Invalid skill identifier: ${identifier}. Use format namespace/slug.`,
+		)
+	}
+	return { namespace: match[1], slug: match[2] }
+}
+
+/**
+ * Vote on a skill (upvote or downvote)
+ * @param skillIdentifier - Skill identifier (namespace/slug)
+ * @param vote - 'up' or 'down'
+ */
+export async function voteSkill(
+	skillIdentifier: string,
+	vote: "up" | "down",
+): Promise<void> {
+	if (!skillIdentifier) {
+		console.error(chalk.red("Error: Skill identifier is required"))
+		console.error(
+			chalk.dim("Usage: smithery skills vote <namespace/slug> --up|--down"),
+		)
+		process.exit(1)
+	}
+
+	let namespace: string
+	let slug: string
+	try {
+		const parsed = parseSkillIdentifier(skillIdentifier)
+		namespace = parsed.namespace
+		slug = parsed.slug
+	} catch (error) {
+		console.error(
+			chalk.red(error instanceof Error ? error.message : String(error)),
+		)
+		process.exit(1)
+	}
+
+	// Voting requires authentication
+	const client = await createClient()
+	if (!client) {
+		console.error(chalk.red("Error: Not logged in."))
+		console.error(chalk.dim("Run 'smithery login' to authenticate."))
+		process.exit(1)
+	}
+
+	const ora = (await import("ora")).default
+	const voteLabel = vote === "up" ? "Upvoting" : "Downvoting"
+	const spinner = ora(`${voteLabel} skill...`).start()
+
+	try {
+		await client.skills.votes.create(slug, {
+			namespace,
+			isPositive: vote === "up",
+		})
+
+		spinner.succeed(`Skill ${vote}voted`)
+	} catch (error) {
+		spinner.fail("Failed to vote on skill")
+		console.error(
+			chalk.red(error instanceof Error ? error.message : String(error)),
+		)
+		process.exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds verb-based commands (`upvote`/`downvote`) instead of flags (`--up`/`--down`) following GitHub CLI design patterns
- Makes vote required when submitting reviews to eliminate ambiguity
- Separates skill voting into its own module (`vote.ts`)
- Updates README.md and SKILL.md documentation

## Changes
- `smithery skills upvote/downvote <skill>` - vote on skills without reviewing
- `smithery skills review add <skill> "text" --up|--down` - submit review with required vote
- `smithery skills review remove <skill>` - remove your review
- `smithery skills review upvote/downvote <skill> <id>` - vote on reviews

## Test plan
- [ ] Run `pnpm test` - all tests pass
- [ ] Manual test: `smithery skills upvote/downvote` commands
- [ ] Manual test: `smithery skills review add` with --up/--down
- [ ] Manual test: `smithery skills review list/remove/upvote/downvote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)