### PR TITLE
feat: add logout command to remove all local credentials

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -185,6 +185,7 @@ See [references/SKILLS.md](references/SKILLS.md) for details.
 | Action | Command |
 |--------|---------|
 | **Authenticate** | `smithery login` |
+| **Log out** | `smithery logout` |
 | **Check auth** | `smithery whoami` |
 | **Search MCP servers** | `smithery search [term]` |
 | **Search skills** | `smithery skills search [term]` |

--- a/references/AUTH.md
+++ b/references/AUTH.md
@@ -18,6 +18,19 @@ This will:
 
 The CLI will wait up to 5 minutes for confirmation.
 
+## Logout
+
+To remove all local credentials:
+
+```bash
+smithery logout
+```
+
+This removes:
+- API key from local settings
+- Namespace configuration
+- All server configurations from keychain
+
 ## Check Auth Status
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,6 +459,31 @@ program
 		}
 	})
 
+// Logout command
+program
+	.command("logout")
+	.description("Log out and remove all local credentials")
+	.action(async () => {
+		const { clearApiKey, clearNamespace } = await import(
+			"./utils/smithery-settings"
+		)
+		const { clearAllConfigs } = await import("./lib/keychain.js")
+
+		console.log(chalk.cyan("Logging out of Smithery..."))
+
+		// Clear API key
+		await clearApiKey()
+
+		// Clear namespace
+		await clearNamespace()
+
+		// Clear keychain entries
+		await clearAllConfigs()
+
+		console.log(chalk.green("✓ Successfully logged out"))
+		console.log(chalk.gray("All local credentials have been removed"))
+	})
+
 // Show API key command
 program
 	.command("whoami")
@@ -539,11 +564,9 @@ program
 				console.log(chalk.cyan("API Key:"), masked)
 				console.log(chalk.gray("Use --full to display the complete key"))
 			}
-		} catch (error) {
-			console.error(chalk.red("✗ Failed to retrieve API key"))
-			const errorMessage =
-				error instanceof Error ? error.message : String(error)
-			console.error(chalk.gray(errorMessage))
+		} catch (_error) {
+			console.log(chalk.yellow("Not logged in"))
+			console.log(chalk.gray("Run 'smithery login' to authenticate"))
 			process.exit(1)
 		}
 	})

--- a/src/utils/smithery-settings.ts
+++ b/src/utils/smithery-settings.ts
@@ -285,6 +285,19 @@ export const clearApiKey = async (): Promise<SettingsResult> => {
 	return await saveSettings(settingsData, getSettingsPath())
 }
 
+export const clearNamespace = async (): Promise<SettingsResult> => {
+	const initResult = await initializeSettings()
+	if (!initResult.success || !initResult.data) {
+		return initResult
+	}
+
+	// Remove namespace from settings
+	const { namespace: _removed, ...settingsWithoutNamespace } = initResult.data
+	settingsData = settingsWithoutNamespace as Settings
+
+	return await saveSettings(settingsData, getSettingsPath())
+}
+
 export const hasAskedConsent = async (): Promise<boolean> => {
 	await initializeSettings()
 	return settingsData?.askedConsent || false


### PR DESCRIPTION
### What's added in this PR?

Added a new `smithery logout` command that removes all local credentials:
- **API key** from settings file
- **Namespace** configuration from settings
- **All keychain entries** for server configs (via `keytar`)

The `whoami` command now shows a helpful message when users are not logged in, prompting them to run `smithery login`. Documentation has been updated in SKILL.md and references/AUTH.md.

### What's the issues or discussion related to this PR?

This feature allows users to completely clear all stored credentials from their system when logging out. Previously, there was no way to remove keychain entries, which could be important for security or when sharing a machine.