### PR TITLE
fix: remove unused --print-link option from login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ smithery connect call <id> [args]   # Call a tool (format: server/tool-name)
 ### Development
 
 ```bash
-smithery login                # Set API key
-smithery login --print-link   # Print auth URL only (agent-friendly)
+smithery login                # Login with Smithery (OAuth)
 smithery dev [entry]          # Dev server with hot-reload and tunnel
 smithery build [entry]        # Build for production
 smithery playground           # Open interactive testing UI

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,27 +416,16 @@ program
 program
 	.command("login")
 	.description("Login with Smithery")
-	.option(
-		"--print-link",
-		"Print auth URL without spinners or browser (agent-friendly)",
-	)
-	.action(async (options) => {
+	.action(async () => {
 		const { executeCliAuthFlow } = await import("./lib/cli-auth")
 		const { validateApiKey } = await import("./lib/registry")
 
-		if (!options.printLink) {
-			console.log(chalk.cyan("Login to Smithery"))
-			console.log()
-		}
+		console.log(chalk.cyan("Login to Smithery"))
+		console.log()
 
 		try {
 			// OAuth flow - uses SMITHERY_BASE_URL env var or defaults to https://smithery.ai
-			const apiKey = await executeCliAuthFlow({ printLink: options.printLink })
-
-			// --print-link just prints URL and exits (no API key returned)
-			if (options.printLink) {
-				return
-			}
+			const apiKey = await executeCliAuthFlow()
 
 			// Keep existing validation and storage
 			await validateApiKey(apiKey)

--- a/src/lib/cli-auth.ts
+++ b/src/lib/cli-auth.ts
@@ -34,8 +34,6 @@ interface PollResponse {
 export interface CliAuthOptions {
 	pollInterval?: number
 	timeoutMs?: number
-	/** Skip browser opening and spinners - just print URL and poll silently */
-	printLink?: boolean
 }
 
 /**
@@ -265,17 +263,12 @@ export async function executeCliAuthFlow(
 ): Promise<string> {
 	verbose(`Starting CLI auth flow with endpoint: ${SMITHERY_URL}`)
 
-	const printLink = options.printLink ?? false
-
 	// Step 1: Create session
-	let sessionSpinner: ReturnType<typeof ora> | null = null
-	if (!printLink) {
-		sessionSpinner = ora({
-			text: "Preparing authentication...",
-			spinner: cliSpinners.dots,
-			color: "cyan",
-		}).start()
-	}
+	const sessionSpinner = ora({
+		text: "Preparing authentication...",
+		spinner: cliSpinners.dots,
+		color: "cyan",
+	}).start()
 
 	let session: CliAuthSession
 	try {
@@ -286,14 +279,7 @@ export async function executeCliAuthFlow(
 		throw error
 	}
 
-	// Step 2: Display URL and optionally open browser
-	if (printLink) {
-		// Agent-friendly: just print the URL and exit (no polling)
-		console.log(session.authUrl)
-		// Return empty string - caller should handle this case
-		return ""
-	}
-
+	// Step 2: Display URL and open browser
 	console.log()
 	console.log(chalk.cyan("Opening browser for authentication..."))
 	console.log()


### PR DESCRIPTION
## Summary
- Remove `--print-link` option from `smithery login` command
- Update README to reflect the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)