### PR TITLE
fix: use GitHub App token for release-please to trigger CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
-# Manual workflow to re-publish to npm in case the automated release failed.
-# Note: Automated publishing is handled by release-please.yml
+# Publishes to npm. Called automatically by release-please when a release is created,
+# or can be triggered manually if needed.
 name: Publish NPM
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,44 +8,26 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
-
-      - uses: pnpm/action-setup@v4
-        if: ${{ steps.release.outputs.release_created }}
-
-      - uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: pnpm add -D @biomejs/cli-linux-x64
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: pnpm run build
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}
-
-      - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          rm -f "$NPM_CONFIG_USERCONFIG"
-          unset NPM_CONFIG_USERCONFIG
-          npm install --prefix ./oidc npm@11.6.2
-          pnpm publish --npm-path "$(pwd)/oidc/node_modules/.bin/npm" --no-git-checks --provenance --access public
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Release PRs created by release-please were not triggering CI checks because `GITHUB_TOKEN` cannot trigger other workflows (GitHub security feature)
- The inline npm publish in release-please.yml was failing with OIDC auth errors

## Changes
- **release-please.yml**: Now uses a GitHub App token so PRs trigger CI workflows
- **publish.yml**: Added `workflow_call` trigger; release-please calls this when a release is created
- Removes duplicate publish code from release-please.yml

## Test plan
- [ ] Merge this PR
- [ ] Check that the next release-please PR has CI checks running
- [ ] Merge a release PR and verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)