### PR TITLE
fix: add id-token permission for npm publish OIDC

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:


### PR DESCRIPTION
Quick fix - the publish workflow needs `id-token:write` for npm provenance, and when called via `workflow_call`, permissions inherit from the parent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)