### PR TITLE
feat: add post-install message and servers search command

### DIFF
--- a/.claude/skills/cli
+++ b/.claude/skills/cli
@@ -1,0 +1,1 @@
+../../.agents/skills/cli

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"description": "An NPX command to install and list Model Context Protocols from Smithery",
 	"main": "dist/index.js",
 	"scripts": {
+		"postinstall": "node scripts/postinstall.js",
 		"build": "tsc && node build.mjs && shx chmod +x dist/index.js",
 		"start": "node dist/index.js",
 		"test:list": "tsx src/index.ts list",
@@ -86,7 +87,8 @@
 	"files": [
 		"dist",
 		"README.md",
-		"package.json"
+		"package.json",
+		"scripts"
 	],
 	"exports": {
 		".": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// Skip in CI environments
+if (process.env.CI || process.env.SMITHERY_SUPPRESS_POSTINSTALL) {
+	process.exit(0)
+}
+
+const line = "=".repeat(60)
+
+console.log(`
+${line}
+  Smithery CLI installed!
+${line}
+
+Get started:
+  smithery --help            Show all commands
+  smithery servers search    Browse MCP servers
+  smithery skills search     Browse skills
+
+Install the Smithery skill to learn how to use this CLI:
+  smithery skills install smithery-ai/cli --agent <agent-name>
+
+Explore 100K+ tools and skills at https://smithery.ai
+${line}
+`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ program
 	.name("smithery")
 	.version(__SMITHERY_VERSION__)
 	.description(
-		`${chalk.bold.italic.hex("#ea580c")("SMITHERY CLI")} ${chalk.bold.italic.hex("#ea580c")(`v${__SMITHERY_VERSION__}`)} - Manage and run MCP servers`,
+		`${chalk.bold.italic.hex("#ea580c")("SMITHERY CLI")} ${chalk.bold.italic.hex("#ea580c")(`v${__SMITHERY_VERSION__}`)} - The marketplace for Agent Skills and MCPs`,
 	)
 	.option("--verbose", "Show detailed logs")
 	.option("--debug", "Show debug logs")
@@ -701,6 +701,37 @@ connect
 	.action(async (toolId, args, options) => {
 		const { callTool } = await import("./commands/connect")
 		await callTool(toolId, args, options)
+	})
+
+// Servers command - search for MCP servers
+const servers = program
+	.command("servers")
+	.description("Search and browse MCP servers")
+
+servers
+	.command("search [term]")
+	.description("Search for servers in the Smithery registry")
+	.option("--json", "Output results as JSON (non-interactive)")
+	.action(async (term, options) => {
+		// API key is optional for search - use if available, don't prompt
+		const apiKey = await getApiKey()
+
+		if (options.json) {
+			const { searchServers } = await import("./lib/registry")
+			// Non-interactive JSON output
+			if (!term) {
+				console.error(
+					chalk.red("Error: Search term is required when using --json"),
+				)
+				process.exit(1)
+			}
+			const servers = await searchServers(term, apiKey)
+			console.log(JSON.stringify({ servers }, null, 2))
+			return
+		}
+
+		const { interactiveServerSearch } = await import("./utils/command-prompts")
+		await interactiveServerSearch(apiKey, term)
 	})
 
 // Skills command - search and install skills


### PR DESCRIPTION
### What's added in this PR?

Adds a friendly post-install message that displays after `npm install -g @smithery/cli`. The message is designed for both humans and AI agents, guiding them to install the Smithery skill and explore the registry. Also adds a new `smithery servers search` command for symmetric UX with the skills search command.

**Changes:**
- New postinstall npm hook displays help and next steps
- Added `smithery servers search` command to browse MCP servers
- Updated CLI tagline to reflect "The marketplace for Agent Skills and MCPs"
- Included scripts folder in npm package distribution

### What's the issues or discussion related to this PR?

Post-install messages are a key part of the user experience after installing the CLI. This ensures users know about the Smithery skill and registry whether they're using the CLI directly or pasting install commands into an agent chat.