### PR TITLE
fix: inline npm publish into release-please workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,9 @@
-# Publishes to npm. Called automatically by release-please when a release is created,
-# or can be triggered manually if needed.
+# Manual npm publish workflow. For automated releases, see release-please.yml.
+# Note: This requires npm OIDC to be configured to trust this workflow file.
 name: Publish NPM
 
 on:
   workflow_dispatch:
-  workflow_call:
 
 permissions:
   contents: read
@@ -32,13 +31,4 @@ jobs:
           ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}
 
       - name: Publish to npm
-        run: |
-          # Remove .npmrc created by setup-node (interferes with OIDC)
-          rm -f "$NPM_CONFIG_USERCONFIG"
-          unset NPM_CONFIG_USERCONFIG
-
-          # Install OIDC-compatible npm version locally
-          npm install --prefix ./oidc npm@11.6.2
-
-          # Use pnpm publish with the local npm binary for OIDC auth
-          pnpm publish --npm-path "$(pwd)/oidc/node_modules/.bin/npm" --no-git-checks --provenance --access public
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,28 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    uses: ./.github/workflows/publish.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm add -D @biomejs/cli-linux-x64
+
+      - run: pnpm run build
+        env:
+          ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
 


### PR DESCRIPTION
### What's added in this PR?

Inline npm publish steps directly into the release-please workflow to fix OIDC authentication for automated releases. This addresses the limitation that npm OIDC trusted publishing only allows one workflow to be configured. When release-please.yml calls publish.yml via workflow_call, the OIDC token claims identify the calling workflow, which npm doesn't recognize.

The publish.yml workflow is now manual-only (workflow_dispatch). The pnpm/local npm workaround that was added in earlier fix attempts has been removed in favor of direct npm publish.

### What's the issues or discussion related to this PR?

**Issue**: Release workflow fails with `ENEEDAUTH` when publishing to npm, but manual workflow_dispatch succeeds.

**Root cause**: npm OIDC trusted publishing can only trust a single workflow file. When triggered via `workflow_call`, the OIDC claims identify the calling workflow (release-please.yml), not the called workflow (publish.yml). Multiple previous fix attempts failed because they only addressed permissions, not this fundamental incompatibility.

**Solution**: Move publish steps into release-please.yml so OIDC claims correctly identify it as the trusted workflow.

**Action required**: Configure npm to trust `.github/workflows/release-please.yml` at https://www.npmjs.com/package/@smithery/cli/access