### PR TITLE
feat: improve search and connect UX for agents

### DIFF
--- a/src/commands/connect/add-impl.ts
+++ b/src/commands/connect/add-impl.ts
@@ -12,6 +12,7 @@ export async function addServer(
 		metadata?: string
 		headers?: string
 		namespace?: string
+		force?: boolean
 	},
 ): Promise<void> {
 	try {
@@ -24,17 +25,74 @@ export async function addServer(
 
 		const normalizedUrl = normalizeMcpUrl(mcpUrl)
 		const session = await ConnectSession.create(options.namespace)
+
+		// Check for existing connections with the same URL
+		if (!options.force) {
+			const { connections: existing } =
+				await session.listConnectionsByUrl(normalizedUrl)
+			if (existing.length > 0) {
+				const match = existing[0]
+				const status = match.status?.state ?? "unknown"
+				console.error(
+					chalk.yellow(
+						`Connection already exists for this URL: ${match.name} (${match.connectionId}, status: ${status})`,
+					),
+				)
+				if (status === "auth_required") {
+					const authUrl = (match.status as { authorizationUrl?: string })
+						?.authorizationUrl
+					if (authUrl) {
+						console.error(
+							chalk.yellow(`Authorization required. Run: open "${authUrl}"`),
+						)
+					}
+				} else if (status === "connected") {
+					console.error(
+						chalk.yellow(
+							`Use "smithery connect tools ${match.connectionId}" to interact with it.`,
+						),
+					)
+				}
+				console.error(
+					chalk.dim(`Use --force to create a new connection anyway.`),
+				)
+				const output = formatConnectionOutput(match)
+				outputJson(output)
+				return
+			}
+		}
+
 		const connection = await session.createConnection(normalizedUrl, {
 			name: options.name,
 			metadata: parsedMetadata,
 			headers: parsedHeaders,
 		})
 
+		if (connection.status?.state === "auth_required") {
+			const authUrl = (connection.status as { authorizationUrl?: string })
+				?.authorizationUrl
+			if (authUrl) {
+				console.error(
+					chalk.yellow(`Authorization required. Run: open "${authUrl}"`),
+				)
+			}
+		}
+
 		const output = formatConnectionOutput(connection)
 		outputJson(output)
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
 		console.error(chalk.red(`Failed to add connection: ${errorMessage}`))
+		if (
+			errorMessage.includes("Missing required permission") ||
+			errorMessage.includes("403")
+		) {
+			console.error(
+				chalk.yellow(
+					`\nYour authentication token may be expired or missing required permissions. Run "smithery login" to re-authenticate.`,
+				),
+			)
+		}
 		process.exit(1)
 	}
 }

--- a/src/commands/connect/api.ts
+++ b/src/commands/connect/api.ts
@@ -44,6 +44,17 @@ export class ConnectSession {
 		return new ConnectSession(client, ns)
 	}
 
+	async listConnectionsByUrl(
+		mcpUrl: string,
+	): Promise<{ connections: Connection[] }> {
+		const data =
+			await this.smitheryClient.experimental.connect.connections.list(
+				this.namespace,
+				{ mcpUrl },
+			)
+		return { connections: data.connections }
+	}
+
 	async listConnections(options?: {
 		limit?: number
 		cursor?: string

--- a/src/commands/connect/list.ts
+++ b/src/commands/connect/list.ts
@@ -25,6 +25,7 @@ export async function listServers(options: {
 		servers: connections.map((conn) => ({
 			id: conn.connectionId,
 			name: conn.name,
+			mcpUrl: conn.mcpUrl,
 			status: conn.status?.state ?? "unknown",
 		})),
 		help: "smithery connect tools <server> - List tools for a specific server",

--- a/src/commands/skills/search.ts
+++ b/src/commands/skills/search.ts
@@ -148,9 +148,7 @@ export async function searchSkills(
 		}))
 		console.log(yaml.stringify(output).replace(/\n\n/g, "\n").trimEnd())
 		console.log()
-		console.log(
-			chalk.dim("Tip: Use --json for machine-readable output"),
-		)
+		console.log(chalk.dim("Tip: Use --json for machine-readable output"))
 		return null
 	} catch (error) {
 		console.error(
@@ -163,7 +161,12 @@ export async function searchSkills(
 
 async function interactiveSearch(
 	client: Smithery,
-	queryParams: { q?: string; pageSize: number; page?: number; namespace?: string },
+	queryParams: {
+		q?: string
+		pageSize: number
+		page?: number
+		namespace?: string
+	},
 	limit: number,
 	initialSearchTerm: string,
 ): Promise<SkillListResponse | null> {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -129,6 +129,7 @@ export const resolveServer = async (
 export const searchServers = async (
 	searchTerm: string,
 	apiKey?: string,
+	filters?: { verified?: boolean; pageSize?: number; page?: number },
 ): Promise<
 	Array<{
 		qualifiedName: string
@@ -145,7 +146,9 @@ export const searchServers = async (
 	try {
 		const response = await smithery.servers.list({
 			q: searchTerm,
-			pageSize: 10,
+			pageSize: filters?.pageSize ?? 10,
+			page: filters?.page,
+			...(filters?.verified && { verified: "true" }),
 		})
 
 		const servers = (response.servers || []).map((server) => ({


### PR DESCRIPTION
## Summary
- **Search improvements**: Make search term optional (shows most popular servers when omitted), add `--verified`, `--limit`, `--page` flags, make search and skills search non-interactive by default
- **Connect duplicate detection**: Check for existing connections before creating new ones, with `--force` flag to bypass. Prevents agent from creating duplicate connections
- **Actionable error messages**: Guide agents to run `open "<auth_url>"` when auth is required, `smithery login` on 403 permission errors
- **Connect list enrichment**: Include `mcpUrl` in `connect list` output so agents can identify what each connection points to
- **URL consistency**: Remove `/mcp` suffix from search `connectionUrl` to match `connect add` expectations

## Test plan
- [x] `smithery search` shows most popular servers
- [x] `smithery search --verified --limit 3` filters and paginates correctly
- [x] `smithery connect add <url>` detects existing connections and shows status-aware guidance
- [x] `smithery connect add <url> --force` creates a new connection regardless
- [x] New connections needing auth show `Run: open "<auth_url>"`
- [x] 403 errors suggest running `smithery login`
- [x] `smithery connect list` includes `mcpUrl` for each connection
- [x] All 271 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)