### PR TITLE
feat: add skills view command

### DIFF
--- a/src/commands/skills/index.ts
+++ b/src/commands/skills/index.ts
@@ -1,4 +1,5 @@
 export { installSkill } from "./install"
 export { deleteReview, listReviews, submitReview, voteReview } from "./review"
 export { searchSkills } from "./search"
+export { viewSkill } from "./view"
 export { voteSkill } from "./vote"

--- a/src/commands/skills/view.ts
+++ b/src/commands/skills/view.ts
@@ -1,0 +1,128 @@
+import chalk from "chalk"
+
+const DEFAULT_BASE_URL = "https://smithery.ai"
+
+/**
+ * Parse a skill view identifier into namespace, slug, and optional file path.
+ * Format: namespace/slug[/path...]
+ */
+function parseIdentifier(identifier: string) {
+	const parts = identifier.split("/")
+	if (parts.length < 2) {
+		throw new Error(
+			`Invalid identifier: ${identifier}. Use format namespace/slug or namespace/slug/path`,
+		)
+	}
+
+	const [namespace, slug, ...rest] = parts
+	const path = rest.length > 0 ? rest.join("/") : "SKILL.md"
+	return { namespace, slug, path, hasSubpath: rest.length > 0 }
+}
+
+/**
+ * Fetch the SKILL.md and extract relative file paths referenced in markdown links.
+ */
+async function showAvailableFiles(
+	baseUrl: string,
+	namespace: string,
+	slug: string,
+) {
+	try {
+		const skillUrl = `${baseUrl}/skills/${namespace}/${slug}/.well-known/skills/SKILL.md`
+		const res = await fetch(skillUrl)
+		if (!res.ok) return
+
+		const content = await res.text()
+		// Match markdown links with relative paths (not http/https URLs)
+		const linkRegex = /\[.*?\]\((?!https?:\/\/)(.*?)\)/g
+		const files = new Set<string>()
+		for (const match of content.matchAll(linkRegex)) {
+			files.add(match[1])
+		}
+		if (files.size > 0) {
+			const MAX_FILES = 10
+			const fileList = [...files].slice(0, MAX_FILES)
+			console.error()
+			console.error("Try:")
+			for (const file of fileList) {
+				console.error(`  smithery skills view ${namespace}/${slug}/${file}`)
+			}
+			if (files.size > MAX_FILES) {
+				console.error(`  ...and ${files.size - MAX_FILES} more`)
+			}
+		}
+	} catch {
+		// Silently ignore - this is a best-effort hint
+	}
+}
+
+/**
+ * View a skill's documentation without installing it.
+ * Fetches files from the .well-known endpoint on smithery.ai.
+ *
+ * @param identifier - namespace/slug or namespace/slug/path
+ */
+export async function viewSkill(identifier: string): Promise<void> {
+	if (!identifier) {
+		console.error(chalk.red("Error: Skill identifier is required"))
+		console.error(
+			chalk.dim("Usage: smithery skills view <namespace/slug[/path]>"),
+		)
+		process.exit(1)
+	}
+
+	let parsed: ReturnType<typeof parseIdentifier>
+	try {
+		parsed = parseIdentifier(identifier)
+	} catch (error) {
+		console.error(
+			chalk.red(error instanceof Error ? error.message : String(error)),
+		)
+		process.exit(1)
+	}
+
+	const { namespace, slug, path, hasSubpath } = parsed
+	const baseUrl = process.env.SMITHERY_BASE_URL || DEFAULT_BASE_URL
+	const url = `${baseUrl}/skills/${namespace}/${slug}/.well-known/skills/${path}`
+
+	try {
+		const response = await fetch(url)
+
+		if (!response.ok) {
+			if (response.status === 404) {
+				console.error(
+					chalk.red(`File not found: ${path} in skill ${namespace}/${slug}`),
+				)
+				if (hasSubpath) {
+					await showAvailableFiles(baseUrl, namespace, slug)
+				}
+			} else {
+				console.error(
+					chalk.red(
+						`Failed to fetch skill file (${response.status}): ${response.statusText}`,
+					),
+				)
+			}
+			process.exit(1)
+		}
+
+		const content = await response.text()
+		console.log(content)
+
+		if (!hasSubpath) {
+			console.log()
+			console.log(
+				chalk.dim(
+					`Tip: View referenced files with: smithery skills view ${namespace}/${slug}/<path>`,
+				),
+			)
+		}
+	} catch (error) {
+		console.error(
+			chalk.red(
+				`Error fetching skill: ${error instanceof Error ? error.message : String(error)}`,
+			),
+		)
+		process.exit(1)
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,6 +814,14 @@ skills
 		})
 	})
 
+skills
+	.command("view <identifier>")
+	.description("View a skill's documentation without installing")
+	.action(async (identifier) => {
+		const { viewSkill } = await import("./commands/skills")
+		await viewSkill(identifier)
+	})
+
 // Uses the Vercel Labs skills CLI: https://github.com/vercel-labs/skills
 skills
 	.command("install <skill>")
@@ -932,23 +940,21 @@ skillsReview
 
 // Show welcome message if no command provided
 if (process.argv.length <= 2) {
-	const line = "=".repeat(60)
-	console.log(`
-${line}
-  ${chalk.bold.hex("#ea580c")("Smithery CLI")} ${chalk.dim(`v${__SMITHERY_VERSION__}`)}
-${line}
-
-Get started:
-  smithery --help            Show all commands
-  smithery servers search    Browse MCP servers
-  smithery skills search     Browse skills
-
-For agents: install the Smithery skill to learn how to use this CLI:
-  smithery skills install smithery-ai/cli --agent <agent-name>
-
-Explore 100K+ tools and skills at ${chalk.cyan("https://smithery.ai")}
-${line}
-`)
+	console.log(
+		`\n${chalk.bold("Smithery")} ${chalk.dim(`v${__SMITHERY_VERSION__}`)} — Discover and connect to 100K+ MCP tools and skills\n`,
+	)
+	const featured = ["connect", "skills", "servers"]
+	const cmds = program.commands.filter((cmd) => featured.includes(cmd.name()))
+	const nameWidth = Math.max(...cmds.map((cmd) => cmd.name().length))
+	console.log("Get started:")
+	for (const cmd of cmds) {
+		const name = cmd.name().padEnd(nameWidth + 2)
+		console.log(`  smithery ${name} ${cmd.description()}`)
+	}
+	console.log(`  smithery ${"help".padEnd(nameWidth + 2)} Show all commands`)
+	console.log()
+	console.log("Run this command to learn how to use this CLI:")
+	console.log(`  smithery skills view smithery-ai/cli\n`)
 	process.exit(0)
 }
 


### PR DESCRIPTION
### What's added in this PR?

Added `smithery skills view <identifier>` command to let agents browse skill documentation without installing. The command fetches files from the `.well-known/skills` endpoint on smithery.ai. Agents can view the main SKILL.md or any referenced files (e.g. `smithery skills view smithery-ai/cli/references/AUTH.md`).

Updated the welcome message to recommend using `smithery skills view smithery-ai/cli` instead of the installation command, making it easier for agents to discover how to use the CLI.

### What's the issues or discussion related to this PR?

This solves the problem that agents couldn't easily learn how to use the CLI without installing a skill. The `.well-known/skills` endpoint is a zero-friction alternative that works for any skill with proper documentation structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)