### PR TITLE
Support interactive mode for skills install

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -824,9 +824,9 @@ skills
 
 // Uses the Vercel Labs skills CLI: https://github.com/vercel-labs/skills
 skills
-	.command("install <skill>")
+	.command("install [skill]")
 	.description("Install a skill (via github.com/vercel-labs/skills)")
-	.requiredOption(
+	.option(
 		"-a, --agent <name>",
 		`Target agent (${SKILL_AGENTS.slice(0, 5).join(", ")}, ...)`,
 	)


### PR DESCRIPTION
### What's added in this PR?

Support for interactive mode in `smithery skills install`. Users can now run:
- `smithery skills install` — fully interactive (prompts for skill and agent)
- `smithery skills install <skill>` — semi-interactive (prompts for agent)  
- `smithery skills install <skill> --agent <agent>` — non-interactive (current behavior)

The change makes both positional `<skill>` and flag `--agent` optional. When either is omitted, `npx skills add` runs without the trailing `-y` flag, allowing the skills CLI's interactive prompts to work. The existing call from search (which always provides both args) continues using non-interactive mode.

### What's the issues or discussion related to this PR?

Previously, `npx skills add` has interactive mode built-in, but we always required both `<skill>` and `--agent` arguments and forced non-interactive mode with `-y`. Since `stdio: "inherit"` was already set when spawning the process, interactive mode would work if we just made the args optional and dropped the trailing `-y` in those cases.