### PR TITLE
fix: keep skill required, only make agent optional

### DIFF
--- a/src/commands/__tests__/skills.test.ts
+++ b/src/commands/__tests__/skills.test.ts
@@ -96,37 +96,17 @@ describe("skills commands use public API", () => {
 		expect(command).toMatch(/-y$/)
 	})
 
-	test("skills install runs interactive mode when no skill provided", async () => {
-		const { execSync } = await import("node:child_process")
-		const { installSkill } = await import("../skills/install")
-
-		await installSkill(undefined, undefined, {})
-
-		expect(execSync).toHaveBeenCalledWith("npx -y skills add", {
-			stdio: "inherit",
-		})
-	})
-
-	test("skills install runs semi-interactive when skill provided but no agent", async () => {
+	test("skills install runs interactive when no agent provided", async () => {
 		const { execSync } = await import("node:child_process")
 		const { installSkill } = await import("../skills/install")
 
 		await installSkill("test-ns/test-skill", undefined, {})
 
 		const command = (execSync as ReturnType<typeof vi.fn>).mock.calls[0][0]
-		expect(command).toContain("npx -y skills add https://smithery.ai/skills/test-ns/test-skill")
+		expect(command).toContain(
+			"npx -y skills add https://smithery.ai/skills/test-ns/test-skill",
+		)
 		// Should NOT have trailing -y
 		expect(command).not.toMatch(/-y$/)
-	})
-
-	test("skills install passes global flag in interactive mode", async () => {
-		const { execSync } = await import("node:child_process")
-		const { installSkill } = await import("../skills/install")
-
-		await installSkill(undefined, undefined, { global: true })
-
-		expect(execSync).toHaveBeenCalledWith("npx -y skills add -g", {
-			stdio: "inherit",
-		})
 	})
 })

--- a/src/commands/skills/install.ts
+++ b/src/commands/skills/install.ts
@@ -46,28 +46,15 @@ export interface InstallOptions {
 /**
  * Install a skill using the Vercel Labs skills CLI
  * https://github.com/vercel-labs/skills
- * @param skillIdentifier - Skill identifier (namespace/slug or URL), omit for interactive mode
+ * @param skillIdentifier - Skill identifier (namespace/slug or URL)
  * @param agent - Target agent for installation, omit to be prompted interactively
  * @param options - Install options (global flag)
  */
 export async function installSkill(
-	skillIdentifier?: string,
+	skillIdentifier: string,
 	agent?: string,
 	options: InstallOptions = {},
 ): Promise<void> {
-	const { execSync } = await import("node:child_process")
-	const globalFlag = options.global ? " -g" : ""
-
-	// No skill provided — fully interactive mode
-	if (!skillIdentifier) {
-		const command = `npx -y skills add${globalFlag}`
-		console.log()
-		console.log(chalk.cyan(`Running: ${command}`))
-		console.log()
-		execSync(command, { stdio: "inherit" })
-		return
-	}
-
 	let skillUrl: string
 
 	try {
@@ -79,7 +66,10 @@ export async function installSkill(
 		process.exit(1)
 	}
 
-	// Skill provided but no agent — semi-interactive (will prompt for agent)
+	const { execSync } = await import("node:child_process")
+	const globalFlag = options.global ? " -g" : ""
+
+	// No agent — interactive (will prompt for agent)
 	if (!agent) {
 		const command = `npx -y skills add ${skillUrl}${globalFlag}`
 		console.log()

--- a/src/index.ts
+++ b/src/index.ts
@@ -824,7 +824,7 @@ skills
 
 // Uses the Vercel Labs skills CLI: https://github.com/vercel-labs/skills
 skills
-	.command("install [skill]")
+	.command("install <skill>")
 	.description("Install a skill (via github.com/vercel-labs/skills)")
 	.option(
 		"-a, --agent <name>",


### PR DESCRIPTION
### What's added in this PR?

Follow-up to #610. Fixes two issues:

1. **Reverts `[skill]` back to `<skill>`** — `npx skills add` requires `<source>`, so skill must remain a required argument. The interactive mode is specifically about agent selection.
2. **Fixes biome formatting** — the lint check was failing due to line length.

Removes the "fully interactive" mode (no skill) since `npx skills add` doesn't support it. The remaining behavior:
- `smithery skills install <skill>` — interactive (prompts for agent)
- `smithery skills install <skill> --agent <agent>` — non-interactive

### What's the issues or discussion related to this PR?

Follow-up fix for #610 which was merged with a failing lint check and an incorrect assumption that `npx skills add` could run without a source argument.