### PR TITLE
feat: add smithery setup command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -938,12 +938,31 @@ skillsReview
 		await voteReview(skill, reviewId, "down")
 	})
 
+// Setup command - install the Smithery CLI skill
+program
+	.command("setup")
+	.description("Install the Smithery CLI skill for your agent")
+	.option(
+		"-a, --agent <name>",
+		`Target agent (${SKILL_AGENTS.slice(0, 5).join(", ")}, ...)`,
+	)
+	.option(
+		"-g, --global",
+		"Install globally (user-level) instead of project-level",
+	)
+	.action(async (options) => {
+		const { installSkill } = await import("./commands/skills")
+		await installSkill("smithery-ai/cli", options.agent, {
+			global: options.global,
+		})
+	})
+
 // Show welcome message if no command provided
 if (process.argv.length <= 2) {
 	console.log(
 		`\n${chalk.bold("Smithery")} ${chalk.dim(`v${__SMITHERY_VERSION__}`)} — Discover and connect to 100K+ MCP tools and skills\n`,
 	)
-	const featured = ["connect", "skills", "servers"]
+	const featured = ["setup", "connect", "skills", "servers"]
 	const cmds = program.commands.filter((cmd) => featured.includes(cmd.name()))
 	const nameWidth = Math.max(...cmds.map((cmd) => cmd.name().length))
 	console.log("Get started:")


### PR DESCRIPTION
### What's added in this PR?

Added a new root-level `smithery setup` command that provides a convenient onboarding path for users. It installs the Smithery CLI skill with a single command instead of requiring `smithery skills install smithery-ai/cli`. The command supports optional `--agent` and `--global` flags for customization and reuses the existing `installSkill` function to maintain consistency with the skills install flow.

The new command is also featured in the welcome message when users run `smithery` with no arguments, making it discoverable for first-time users.

### What's the issues or discussion related to this PR?

This addresses the request to create a `smithery setup` command that provides a shortcut for bootstrapping the Smithery CLI skill interactively without requiring login, since skill lookup uses a public API endpoint.