### PR TITLE
fix(SMI-1470): improve auth error messages for expired tokens

### DIFF
--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -1,3 +1,4 @@
+import { AuthenticationError } from "@smithery/api"
 import chalk from "chalk"
 import { errorMessage, fatal } from "../../lib/cli-error"
 import { isJsonMode, outputDetail } from "../../utils/output"
@@ -89,6 +90,17 @@ export async function addServer(
 			tip: `Call tools: smithery tool call ${id} <tool> '<args>'\nList tools: smithery tool list ${id}`,
 		})
 	} catch (error) {
+		if (error instanceof AuthenticationError) {
+			console.error(
+				chalk.red("Failed to add connection: Authentication failed."),
+			)
+			console.error(
+				chalk.yellow(
+					'\nYour API key may be expired. Run "smithery login" to re-authenticate.',
+				),
+			)
+			process.exit(1)
+		}
 		const msg = errorMessage(error)
 		if (msg.includes("Missing required permission") || msg.includes("403")) {
 			console.error(chalk.red(`Failed to add connection: ${msg}`))

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -37,8 +37,13 @@ function getErrorMessage(
 export function createError(error: unknown, context: string): Error {
 	// Handle specific API error types with user-friendly messages
 	if (error instanceof AuthenticationError) {
-		const errorMessage = getErrorMessage(error, "Unauthorized: Invalid API key")
-		return new Error(errorMessage, { cause: error })
+		const serverMessage = error.message || ""
+		const primary = serverMessage
+			? `Authentication failed: ${serverMessage}`
+			: "Authentication failed: Your API key may be expired or invalid."
+		return new Error(`${primary}\nRun "smithery login" to re-authenticate.`, {
+			cause: error,
+		})
 	}
 	if (error instanceof ConflictError) {
 		const errorMessage = getErrorMessage(error, "already exists")

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -298,7 +298,9 @@ export async function ensureApiKey(apiKey?: string): Promise<string> {
 		// Handle invalid API key (401 error)
 		if (error instanceof AuthenticationError) {
 			console.error(
-				chalk.red("✗ Invalid API key detected. Please enter a valid API key."),
+				chalk.red(
+					'✗ API key is expired or invalid. Run "smithery login" to re-authenticate.',
+				),
 			)
 
 			// Clear invalid saved key if it was from config (not command line)
@@ -315,7 +317,7 @@ export async function ensureApiKey(apiKey?: string): Promise<string> {
 				if (validationError instanceof AuthenticationError) {
 					console.error(
 						chalk.red(
-							"✗ Invalid API key. Please check your API key and try again.",
+							'✗ API key is invalid. Please check your key or run "smithery login" to get a new one.',
 						),
 					)
 					throw validationError


### PR DESCRIPTION
## Summary
- Updated `AuthenticationError` messages across the CLI to mention token expiration and suggest running `smithery login`
- Added explicit `AuthenticationError` handling in the `add` command (previously only caught 403 errors)
- Centralized error handler (`createError`) now includes the server's error message when available

Closes SMI-1470

## Test plan
- [ ] Set an expired/invalid API key and run any command — verify error suggests `smithery login`
- [ ] Run `smithery add <url>` with an expired key — verify the add-specific error path shows the message
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)