### PR TITLE
perf: lazy-install keytar to eliminate native build

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -70,6 +70,7 @@ define.__LAZY_DEPS__ = JSON.stringify({
 	miniflare: packageJson.devDependencies.miniflare,
 	esbuild: packageJson.devDependencies.esbuild,
 	"@ngrok/ngrok": packageJson.devDependencies["@ngrok/ngrok"],
+	keytar: packageJson.devDependencies.keytar,
 })
 
 console.log("✓ Compiled bootstrap files")

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"flexsearch": "^0.7.43",
 		"inquirer": "^8.2.4",
 		"inquirer-autocomplete-prompt": "^2.0.0",
+		"keytar": "^7.9.0",
 		"knip": "^5.80.0",
 		"miniflare": "^4.20260103.0",
 		"picocolors": "^1.1.0",
@@ -91,8 +92,5 @@
 	},
 	"engines": {
 		"node": ">=20.0.0"
-	},
-	"optionalDependencies": {
-		"keytar": "^7.9.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       inquirer-autocomplete-prompt:
         specifier: ^2.0.0
         version: 2.0.1(inquirer@8.2.7(@types/node@20.19.27))
+      keytar:
+        specifier: ^7.9.0
+        version: 7.9.0
       knip:
         specifier: ^5.80.0
         version: 5.80.0(@types/node@20.19.27)(typescript@5.9.3)
@@ -105,10 +108,6 @@ importers:
       zod-to-json-schema:
         specifier: ^3.25.1
         version: 3.25.1(zod@4.2.1)
-    optionalDependencies:
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
 
 packages:
 
@@ -2970,8 +2969,7 @@ snapshots:
 
   check-error@2.1.1: {}
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -3041,12 +3039,10 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
   deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   defaults@1.0.4:
     dependencies:
@@ -3145,8 +3141,7 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -3255,8 +3250,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -3303,8 +3297,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3348,8 +3341,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   inquirer-autocomplete-prompt@2.0.1(inquirer@8.2.7(@types/node@20.19.27)):
     dependencies:
@@ -3436,7 +3428,6 @@ snapshots:
     dependencies:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.3
-    optional: true
 
   kleur@4.1.5: {}
 
@@ -3491,8 +3482,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-response@3.1.0: {}
 
   miniflare@4.20260103.0:
     dependencies:
@@ -3514,8 +3504,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
 
@@ -3525,8 +3514,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
 
@@ -3535,10 +3523,8 @@ snapshots:
   node-abi@3.85.0:
     dependencies:
       semver: 7.7.3
-    optional: true
 
-  node-addon-api@4.3.0:
-    optional: true
+  node-addon-api@4.3.0: {}
 
   node-forge@1.3.3: {}
 
@@ -3643,7 +3629,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   pretty-bytes@5.6.0: {}
 
@@ -3678,7 +3663,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   readable-stream@3.6.2:
     dependencies:
@@ -3874,15 +3858,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   simple-swizzle@0.2.4:
     dependencies:
@@ -3916,8 +3898,7 @@ snapshots:
 
   strip-eof@1.0.0: {}
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -3939,7 +3920,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.3
       tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -3948,7 +3928,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   through@2.3.8: {}
 
@@ -3989,7 +3968,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   type-fest@0.21.3: {}
 


### PR DESCRIPTION
## Summary
- Move `keytar` from `optionalDependencies` to `devDependencies` and use `lazyImport()` for on-demand installation
- Removes the ~5s native `prebuild-install` compilation step from `npm install @smithery/cli`
- Users are prompted to install keytar on first use of keychain features (mcp add/run/remove)

## Context
After v4.1.0 optimizations, keytar's native build was the single largest remaining cost in user install time (~5s of the 6.5s total). Since keytar is only needed when saving/reading credentials from the OS keychain, it can be lazily installed on first use.

## Test plan
- [x] `pnpm build` passes
- [x] All 334 tests pass
- [x] Fresh `npm install` no longer triggers native compilation
- [x] `smithery mcp add` prompts to install keytar on first use
- [x] Keychain save/read/delete work after lazy install

🤖 Generated with [Claude Code](https://claude.com/claude-code)