### PR TITLE
fix: prevent platform mismatch in lazy dependency install

### DIFF
--- a/src/lib/lazy-import.ts
+++ b/src/lib/lazy-import.ts
@@ -63,7 +63,7 @@ export async function lazyImport<T = unknown>(packageName: string): Promise<T> {
 	const spinner = yoctoSpinner({ text: `Installing ${spec}...` }).start()
 
 	try {
-		execSync(`npm install --no-save ${spec}`, {
+		execSync(`npm install --no-save --no-package-lock --omit=dev ${spec}`, {
 			cwd: cliRoot,
 			stdio: ["pipe", "pipe", "pipe"],
 		})


### PR DESCRIPTION
## Summary
- Add `--omit=dev` and `--no-package-lock` flags to the `npm install` command in `lazyImport()` to prevent npm from resolving devDependencies (like `@biomejs/biome`) that pull in platform-specific binaries incompatible with the host OS.

Closes #642

## Test plan
- [x] Removed esbuild from global CLI node_modules and ran `smithery mcp publish` from a test MCP project — esbuild lazily installed without `EBADPLATFORM` error
- [x] Full publish succeeded end-to-end (build, scan, upload)
- [x] All 338 tests pass
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)