### PR TITLE
fix: remove explicit biome linux binary from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install
-      - run: pnpm add -D @biomejs/cli-linux-x64  # biome platform binary for linux ci
       - run: pnpm run check
 
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm add -D @biomejs/cli-linux-x64
-
       - run: pnpm run build
         env:
           ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,8 +56,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm add -D @biomejs/cli-linux-x64
-
       - run: pnpm run build
         env:
           ANALYTICS_ENDPOINT: ${{ secrets.ANALYTICS_ENDPOINT }}
@@ -103,7 +101,6 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm add -D @biomejs/cli-linux-x64
       - run: pnpm run check
 
   preview-publish:
@@ -125,8 +122,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
-
-      - run: pnpm add -D @biomejs/cli-linux-x64
 
       - name: Set preview version from tag
         run: |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"packageManager": "pnpm@10.27.0",
 	"pnpm": {
 		"onlyBuiltDependencies": [
+			"@biomejs/biome",
 			"esbuild",
 			"keytar",
 			"@smithery/api",


### PR DESCRIPTION
## Summary
- Remove `pnpm add -D @biomejs/cli-linux-x64` workaround from all CI workflows (build, publish, release-please)
- Add `@biomejs/biome` to `onlyBuiltDependencies` in package.json so pnpm resolves the correct platform binary automatically
- This was the root cause of #642: the publish workflow leaked `@biomejs/cli-linux-x64` into the published package.json, causing `EBADPLATFORM` errors on non-linux platforms

## Test plan
- [x] CI lint job passes without explicit biome linux binary
- [x] CI publish job produces a clean package.json (no `@biomejs/cli-linux-x64` in devDependencies)
- [x] All 338 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)