### PR TITLE
chore: add hidden mcp secrets subcommands

### DIFF
--- a/src/commands/mcp/secrets.ts
+++ b/src/commands/mcp/secrets.ts
@@ -1,0 +1,112 @@
+import pc from "picocolors"
+import { fatal } from "../../lib/cli-error"
+import { createSmitheryClient } from "../../lib/smithery-client"
+import { isJsonMode, outputJson, outputTable } from "../../utils/output"
+
+export async function listSecrets(server: string) {
+	const client = await createSmitheryClient()
+
+	try {
+		const secrets = await client.servers.secrets.list(server)
+
+		const data = secrets.map((s) => ({
+			name: s.name,
+			type: s.type,
+		}))
+
+		outputTable({
+			data,
+			columns: [
+				{ key: "name", header: "NAME" },
+				{ key: "type", header: "TYPE" },
+			],
+			json: isJsonMode(),
+			jsonData: { secrets: data, server },
+			tip:
+				data.length === 0
+					? `No secrets found. Use 'smithery mcp secrets set ${server}' to add one.`
+					: `Use 'smithery mcp secrets set ${server}' to add or update a secret.`,
+		})
+	} catch (error) {
+		fatal("Failed to list secrets", error)
+	}
+}
+
+export async function setSecret(
+	server: string,
+	options: { name?: string; value?: string },
+) {
+	let { name, value } = options
+
+	if (!name || !value) {
+		if (!process.stdin.isTTY) {
+			fatal(
+				"Missing --name and/or --value flags (required in non-interactive mode)",
+			)
+		}
+
+		const inquirer = (await import("inquirer")).default
+
+		if (!name) {
+			const answer = await inquirer.prompt([
+				{
+					type: "input",
+					name: "name",
+					message: "Secret name:",
+					validate: (input: string) =>
+						input.trim() ? true : "Secret name is required",
+				},
+			])
+			name = answer.name
+		}
+
+		if (!value) {
+			const answer = await inquirer.prompt([
+				{
+					type: "password",
+					name: "value",
+					message: `Value for ${name}:`,
+					mask: "*",
+					validate: (input: string) =>
+						input.trim() ? true : "Secret value is required",
+				},
+			])
+			value = answer.value
+		}
+	}
+
+	const client = await createSmitheryClient()
+
+	try {
+		const result = await client.servers.secrets.set(server, {
+			name: name!,
+			value: value!,
+		})
+
+		if (isJsonMode()) {
+			outputJson({ success: result.success, server, name })
+		} else {
+			console.log(`${pc.green("✓")} Secret "${name}" set for ${server}`)
+		}
+	} catch (error) {
+		fatal("Failed to set secret", error)
+	}
+}
+
+export async function deleteSecret(server: string, name: string) {
+	const client = await createSmitheryClient()
+
+	try {
+		const result = await client.servers.secrets.delete(name, {
+			qualifiedName: server,
+		})
+
+		if (isJsonMode()) {
+			outputJson({ success: result.success, server, name })
+		} else {
+			console.log(`${pc.green("✓")} Secret "${name}" deleted from ${server}`)
+		}
+	} catch (error) {
+		fatal("Failed to delete secret", error)
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,21 @@ async function handleMcpRemove(ids: string[], options: any) {
 	await handleRemoveConnections(ids, options)
 }
 
+async function handleSecretsList(server: string) {
+	const { listSecrets } = await import("./commands/mcp/secrets")
+	await listSecrets(server)
+}
+
+async function handleSecretsSet(server: string, options: any) {
+	const { setSecret } = await import("./commands/mcp/secrets")
+	await setSecret(server, options)
+}
+
+async function handleSecretsDelete(server: string, name: string) {
+	const { deleteSecret } = await import("./commands/mcp/secrets")
+	await deleteSecret(server, name)
+}
+
 async function handleLogin() {
 	const { executeCliAuthFlow } = await import("./lib/cli-auth")
 	const { validateApiKey } = await import("./lib/registry")
@@ -678,6 +693,49 @@ const runCmd = mcpCmd
 	.command("run <server>", { hidden: true })
 	.option("--config <json>", "Provide configuration as JSON")
 	.action(handleRun)
+
+// ─── Secrets (hidden — not GA) ──────────────────────────────────────────────
+
+const secretsCmd = mcpCmd
+	.command("secrets", { hidden: true })
+	.description("Manage secrets for published MCP servers")
+
+secretsCmd
+	.command("list <server>")
+	.description("List secret names for a server")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery mcp secrets list my-org/my-server
+  smithery mcp secrets list my-org/my-server --json`,
+	)
+	.action(handleSecretsList)
+
+secretsCmd
+	.command("set <server>")
+	.description("Set a secret for a server")
+	.option("--name <name>", "Secret name")
+	.option("--value <value>", "Secret value")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery mcp secrets set my-org/my-server --name API_KEY --value sk-xxx
+  smithery mcp secrets set my-org/my-server`,
+	)
+	.action(handleSecretsSet)
+
+secretsCmd
+	.command("delete <server> <name>")
+	.description("Delete a secret from a server")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery mcp secrets delete my-org/my-server API_KEY`,
+	)
+	.action(handleSecretsDelete)
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Tool command — Find and call tools from MCP servers added via 'smithery mcp'


### PR DESCRIPTION
### What's added in this PR?

Implemented three new `smithery mcp secrets` subcommands for developers to manage secrets on published MCP servers:

- **`smithery mcp secrets list <server>`** — List secret names and types (values never exposed)
- **`smithery mcp secrets set <server>`** — Create/update a secret with `--name` and `--value` flags or interactive prompts
- **`smithery mcp secrets delete <server> <name>`** — Delete a secret from a server

All commands are **hidden** (`{ hidden: true }`) since the feature is not yet GA. They won't appear in `smithery mcp --help` but are fully functional when accessed via `smithery mcp secrets --help`.

The implementation:
- Uses the existing `@smithery/api` SDK `client.servers.secrets.{list,set,delete}` methods
- Supports both interactive (TTY with prompts) and non-interactive (flags-based) modes
- Respects `--json` flag for agent-friendly output
- Uses `inquirer` for interactive secret value input with password masking
- Includes helpful tips and examples in help text

#### Screenshots

N/A (CLI feature)

### What's the issues or discussion related to this PR?

Developers publishing MCP servers need a secure way to manage environment variables and API keys for their servers. The backend already supports secrets storage via Cloudflare's Secrets Store. This PR adds the CLI layer to expose that functionality, allowing developers to:

1. List what secrets are configured for their server
2. Set new secrets (with secure password prompts in interactive mode)
3. Remove secrets they no longer need

The commands are marked hidden to allow for refinement before the feature becomes generally available.