### PR TITLE
fix: use --save-prod for lazy install to prevent silent no-op

### DIFF
--- a/src/lib/lazy-import.ts
+++ b/src/lib/lazy-import.ts
@@ -64,7 +64,7 @@ export async function lazyImport<T = unknown>(packageName: string): Promise<T> {
 	const spinner = yoctoSpinner({ text: `Installing ${spec}...` }).start()
 
 	try {
-		execSync(`npm install --no-save --no-package-lock --omit=dev ${spec}`, {
+		execSync(`npm install --save-prod --no-package-lock --omit=dev ${spec}`, {
 			cwd: cliRoot,
 			stdio: ["pipe", "pipe", "pipe"],
 		})


### PR DESCRIPTION
## Summary
- The published package.json has all deps in `devDependencies` (since the CLI is bundled). With `--no-save --omit=dev`, npm considers the newly installed lazy package (e.g. esbuild) extraneous and exits 0 **without actually installing it**.
- Replace `--no-save` with `--save-prod` so the package is promoted from `devDependencies` to `dependencies`, making `--omit=dev` install only the target package (not the entire dev tree).

## Test plan
- [x] All 338 existing tests pass
- [ ] Manually test `smithery mcp build` on a fresh global install where esbuild is not yet installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)