### PR TITLE
chore: use positional args for secret set command

### DIFF
--- a/src/commands/mcp/secrets.ts
+++ b/src/commands/mcp/secrets.ts
@@ -41,7 +41,7 @@ export async function setSecret(
 	if (!name || !value) {
 		if (!process.stdin.isTTY) {
 			fatal(
-				"Missing --name and/or --value flags (required in non-interactive mode)",
+				"Missing name and/or value arguments (required in non-interactive mode)",
 			)
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,9 +298,13 @@ async function handleSecretsList(server: string) {
 	await listSecrets(server)
 }
 
-async function handleSecretsSet(server: string, options: any) {
+async function handleSecretsSet(
+	server: string,
+	name: string | undefined,
+	value: string | undefined,
+) {
 	const { setSecret } = await import("./commands/mcp/secrets")
-	await setSecret(server, options)
+	await setSecret(server, { name, value })
 }
 
 async function handleSecretsDelete(server: string, name: string) {
@@ -743,15 +747,13 @@ Examples:
 	.action(handleSecretsList)
 
 secretsCmd
-	.command("set <server>")
+	.command("set <server> [name] [value]")
 	.description("Set a secret for a server")
-	.option("--name <name>", "Secret name")
-	.option("--value <value>", "Secret value")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  smithery mcp secrets set my-org/my-server --name API_KEY --value sk-xxx
+  smithery mcp secrets set my-org/my-server API_KEY sk-xxx
   smithery mcp secrets set my-org/my-server`,
 	)
 	.action(handleSecretsSet)


### PR DESCRIPTION
## Summary
- Changed `smithery mcp secrets set` to accept `name` and `value` as optional positional arguments instead of `--name`/`--value` flags
- If positional args are omitted, interactive prompts are used (existing behavior preserved)

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm test` — all 338 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)