### PR TITLE
chore(SMI-1552): add events poll command and update SDK to 0.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@biomejs/biome": "2.3.10",
 		"@modelcontextprotocol/sdk": "^1.25.3",
 		"@ngrok/ngrok": "^1.5.1",
-		"@smithery/api": "0.49.0",
+		"@smithery/api": "0.52.0",
 		"@smithery/sdk": "^4.0.1",
 		"@types/inquirer": "^8.2.4",
 		"@types/inquirer-autocomplete-prompt": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.5.1
         version: 1.7.0
       '@smithery/api':
-        specifier: 0.49.0
-        version: 0.49.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
+        specifier: 0.52.0
+        version: 0.52.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
       '@smithery/sdk':
         specifier: ^4.0.1
         version: 4.0.1(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))(zod@4.2.1)
@@ -881,8 +881,8 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
-  '@smithery/api@0.49.0':
-    resolution: {integrity: sha512-VfF2Nu4Wn1RWrV5BxZcQRH/NTYDrSeU8SxTPpRo80jW6JZD3ez5T48vIMe7yFLl0aLYV704ho+Qr8394lgskSA==}
+  '@smithery/api@0.52.0':
+    resolution: {integrity: sha512-PRN27yr4J0GT2X29f1prw4gIC+52D9Aa80yr76wfPzdcYXEwBz0XVia/SDhbYuyS0WKdeSTdisTRZ2EqXQtGEg==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
     peerDependenciesMeta:
@@ -2785,7 +2785,7 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@smithery/api@0.49.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
+  '@smithery/api@0.52.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.1)(zod@4.2.1)
 

--- a/src/commands/event/index.ts
+++ b/src/commands/event/index.ts
@@ -1,3 +1,4 @@
+export { pollEvents } from "./poll"
 export { subscribeEvents } from "./subscribe"
 export { listTopics } from "./topics"
 export { unsubscribeEvents } from "./unsubscribe"

--- a/src/commands/event/poll.ts
+++ b/src/commands/event/poll.ts
@@ -1,0 +1,62 @@
+import pc from "picocolors"
+import { fatal } from "../../lib/cli-error"
+import { isJsonMode, outputJson, outputTable } from "../../utils/output"
+import { ConnectSession } from "../mcp/api"
+
+export async function pollEvents(
+	connection: string,
+	options: { namespace?: string; limit?: string },
+): Promise<void> {
+	const isJson = isJsonMode()
+
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		const result = await session.pollEvents(connection, {
+			limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+		})
+
+		if (isJson) {
+			outputJson(result)
+			return
+		}
+
+		if (result.data.length === 0) {
+			console.log(pc.dim("No events in queue."))
+			return
+		}
+
+		const data = result.data.map((event) => ({
+			id: String(event.id),
+			method: String((event.payload as Record<string, unknown>).method ?? ""),
+			createdAt: formatTimestamp(event.createdAt),
+		}))
+
+		outputTable({
+			data,
+			columns: [
+				{ key: "id", header: "ID" },
+				{ key: "method", header: "METHOD" },
+				{ key: "createdAt", header: "CREATED AT" },
+			],
+			json: false,
+			jsonData: result,
+			tip: result.done
+				? "All events consumed. Poll again later for new events."
+				: "More events available. Poll again to retrieve the next batch.",
+		})
+	} catch (error) {
+		fatal("Failed to poll events", error)
+	}
+}
+
+function formatTimestamp(iso: string): string {
+	const d = new Date(iso)
+	return d.toLocaleString("en-US", {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hour12: false,
+	})
+}

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -219,6 +219,19 @@ export class ConnectSession {
 			namespace: this.namespace,
 		})
 	}
+
+	async pollEvents(connectionId: string, options?: { limit?: number }) {
+		return this.smitheryClient.get<{
+			data: Array<{
+				id: number
+				payload: Record<string, unknown>
+				createdAt: string
+			}>
+			done: boolean
+		}>(`/connect/${this.namespace}/${connectionId}/events`, {
+			query: options?.limit ? { limit: options.limit } : undefined,
+		})
+	}
 }
 
 async function getCurrentNamespace(): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -899,6 +899,16 @@ Examples:
 		await unsubscribeEvents(connection, topic, options)
 	})
 
+eventCmd
+	.command("poll <connection>")
+	.description("Poll for queued events from a connection")
+	.option("--namespace <ns>", "Namespace for the connection")
+	.option("--limit <n>", "Maximum events to return (1-100, default 100)")
+	.action(async (connection: string, options: any) => {
+		const { pollEvents } = await import("./commands/event")
+		await pollEvents(connection, options)
+	})
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Skill command — Search, view, and install Smithery skills
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/utils/install/__tests__/fixtures/servers.ts
+++ b/src/utils/install/__tests__/fixtures/servers.ts
@@ -11,6 +11,9 @@ export const noConfigServer: Server = {
 	deploymentUrl: null,
 	security: null,
 	tools: null,
+	eventTopics: null,
+	prompts: null,
+	resources: null,
 	connections: [
 		{
 			type: "stdio",
@@ -28,6 +31,9 @@ export const requiredOnlyServer: Server = {
 	deploymentUrl: "https://server.smithery.ai",
 	security: null,
 	tools: null,
+	eventTopics: null,
+	prompts: null,
+	resources: null,
 	connections: [
 		{
 			type: "http",
@@ -57,6 +63,9 @@ export const requiredAndOptionalServer: Server = {
 	deploymentUrl: null,
 	security: null,
 	tools: null,
+	eventTopics: null,
+	prompts: null,
+	resources: null,
 	connections: [
 		{
 			type: "stdio",


### PR DESCRIPTION
## Summary
- Add `smithery event poll <connection>` command to poll queued server-to-client events from a connection's REST endpoint
- Update `@smithery/api` SDK from 0.49.0 to 0.52.0
- Fix test fixtures for new required fields in `ServerGetResponse` (`eventTopics`, `prompts`, `resources`)

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm test` — all 338 tests pass
- [x] `smithery event poll --help` shows correct usage
- [x] `smithery events poll --help` works via plural alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)