### PR TITLE
fix: list event topics without requiring MCP handshake

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -23,22 +23,22 @@ export type EventTopic = z.infer<typeof EventTopicSchema>
  * Paginates through all pages automatically.
  */
 export async function listEventTopics(client: Client) {
-	const capabilities = client.getServerCapabilities()
-	if (!capabilities?.experimental?.["ai.smithery/events"]) {
-		return { eventTopics: [] }
-	}
-
 	const eventTopics: EventTopic[] = []
 	let cursor: string | undefined
-	do {
-		// biome-ignore lint/suspicious/noExplicitAny: custom JSON-RPC method not in SDK types
-		const result = await (client.request as any)(
-			{ method: "ai.smithery/events/topics/list", params: { cursor } },
-			ListEventTopicsResultSchema,
-		)
-		eventTopics.push(...result.topics)
-		cursor = result.nextCursor
-	} while (cursor)
+	try {
+		do {
+			// biome-ignore lint/suspicious/noExplicitAny: custom JSON-RPC method not in SDK types
+			const result = await (client.request as any)(
+				{ method: "ai.smithery/events/topics/list", params: { cursor } },
+				ListEventTopicsResultSchema,
+			)
+			eventTopics.push(...result.topics)
+			cursor = result.nextCursor
+		} while (cursor)
+	} catch {
+		// Server does not support events extension
+		return { eventTopics: [] }
+	}
 
 	return { eventTopics }
 }


### PR DESCRIPTION
## Summary
- Smithery Connect skips the MCP initialize handshake for performance (`sessionId: 'smithery-stateless'` tricks the SDK into thinking it's reconnecting)
- This means `client.getServerCapabilities()` is never populated — it returns `undefined`
- `listEventTopics` was checking capabilities before calling `topics/list`, so it always returned empty
- Replace the capability pre-check with a try/catch around the actual request, matching how `subscribe` already works

## Test plan
- [x] All 338 existing tests pass
- [x] Verified locally: `event topics` returns all 13 GitHub event topics against `smithery/test-github`

🤖 Generated with [Claude Code](https://claude.com/claude-code)