### PR TITLE
feat(SMI-1462): add --prompt option to auth token command

### DIFF
--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -2,7 +2,10 @@ import { fatal } from "../../lib/cli-error"
 import { createSmitheryClient } from "../../lib/smithery-client"
 import { isJsonMode, outputDetail } from "../../utils/output"
 
-export async function createToken(options: { policy?: string }) {
+export async function createToken(options: {
+	policy?: string
+	prompt?: string
+}) {
 	const isJson = isJsonMode()
 
 	let policy: Array<Record<string, unknown>> | undefined
@@ -15,15 +18,30 @@ export async function createToken(options: { policy?: string }) {
 		}
 	}
 
+	const body: Record<string, unknown> = {}
+	if (policy) body.policy = policy
+	if (options.prompt) body.prompt = options.prompt
+
+	if (!body.policy && !body.prompt) {
+		fatal(
+			"At least one of --policy or --prompt is required to mint a scoped token.",
+		)
+	}
+
 	try {
 		const client = await createSmitheryClient()
-		const result = await client.tokens.create(policy ? { policy } : undefined)
+		const result = await client.tokens.create(body)
+
+		const data: Record<string, unknown> = {
+			token: result.token,
+			expiresAt: result.expiresAt,
+		}
+		if ("generatedPolicy" in result && result.generatedPolicy) {
+			data.generatedPolicy = result.generatedPolicy
+		}
 
 		outputDetail({
-			data: {
-				token: result.token,
-				expiresAt: result.expiresAt,
-			},
+			data,
 			json: isJson,
 			tip: "Set SMITHERY_API_KEY=<token> to use this token.",
 		})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1110,7 +1110,10 @@ auth
 	.command("token")
 	.description("Mint a restricted service token")
 	.option("--policy <json>", "Policy constraints as JSON array")
-
+	.option(
+		"--prompt <text>",
+		"Natural language description of token permissions (experimental)",
+	)
 	.action(async (options) => {
 		const { createToken } = await import("./commands/auth/token")
 		await createToken(options)


### PR DESCRIPTION
### What's added in this PR?

Adds support for LLM-powered token constraint generation (from SDK PR #1619). Users can now pass `--prompt` to `smithery auth token` to describe desired permissions in natural language, and the API generates valid constraints automatically. The response includes `generatedPolicy` showing what was generated.

**Changes:**
- Add `--prompt <text>` option to `auth token` command
- Update `createToken` to accept and send both `--policy` and `--prompt`
- Display `generatedPolicy` in token output when available
- Require at least one of `--policy` or `--prompt` to mint service tokens

### What's the issues or discussion related to this PR?

This follows SDK PR #1619 which implements Phase 2 of token scoping with LLM-powered constraint generation. The CLI changes enable users to leverage this new capability via the command line.

**Note:** The `@smithery/api` SDK types will be updated separately when the SDK version is bumped. The `generatedPolicy` field is currently accessed defensively using `in` operator to avoid type errors.