### PR TITLE
chore(SMI-1567): add prefix filtering to tool list and event topics

### DIFF
--- a/src/commands/__tests__/tools-find.test.ts
+++ b/src/commands/__tests__/tools-find.test.ts
@@ -95,6 +95,88 @@ describe("tools find command", () => {
 		)
 	})
 
+	test("filters tools by name prefix", async () => {
+		mockGetConnection.mockResolvedValue({
+			connectionId: "github-abc",
+			name: "github-abc",
+			status: { state: "connected" },
+		})
+		mockListToolsForConnection.mockResolvedValue([
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "issues.create",
+				description: "Create an issue",
+				inputSchema: { type: "object" },
+			},
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "issues.list",
+				description: "List issues",
+				inputSchema: { type: "object" },
+			},
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "pulls.create",
+				description: "Create a pull request",
+				inputSchema: { type: "object" },
+			},
+		])
+
+		await findTools(undefined, {
+			connection: "github-abc",
+			prefix: "issues.",
+			all: true,
+		})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					total: 2,
+					prefix: "issues.",
+					tools: expect.arrayContaining([
+						expect.objectContaining({ name: "issues.create" }),
+						expect.objectContaining({ name: "issues.list" }),
+					]),
+				}),
+			}),
+		)
+	})
+
+	test("prefix with no matches returns empty result", async () => {
+		mockGetConnection.mockResolvedValue({
+			connectionId: "github-abc",
+			name: "github-abc",
+			status: { state: "connected" },
+		})
+		mockListToolsForConnection.mockResolvedValue([
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "pulls.create",
+				description: "Create a PR",
+				inputSchema: { type: "object" },
+			},
+		])
+
+		await findTools(undefined, {
+			connection: "github-abc",
+			prefix: "issues.",
+			all: true,
+		})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					total: 0,
+					tools: [],
+				}),
+			}),
+		)
+	})
+
 	test("supports listing behavior via find --all without a query", async () => {
 		mockListConnections.mockResolvedValue({
 			connections: [

--- a/src/commands/mcp/search.ts
+++ b/src/commands/mcp/search.ts
@@ -117,6 +117,7 @@ export async function findTools(
 		page?: string
 		all?: boolean
 		match?: string
+		prefix?: string
 	},
 ): Promise<void> {
 	const isJson = isJsonMode()
@@ -227,8 +228,14 @@ export async function findTools(
 		return
 	}
 
+	const candidates = options.prefix
+		? allTools.filter((tool) =>
+				tool.name.toLowerCase().startsWith(options.prefix!.toLowerCase()),
+			)
+		: allTools
+
 	const matches = matchTools(
-		allTools,
+		candidates,
 		normalizedQuery,
 		mode,
 		limit,
@@ -249,6 +256,7 @@ export async function findTools(
 			tools: data,
 			total: matches.length,
 			mode,
+			...(options.prefix ? { prefix: options.prefix } : {}),
 			...(normalizedQuery ? { query: normalizedQuery } : {}),
 			...(options.all
 				? { all: true, page: 1, hasMore: false }

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,7 +800,7 @@ Examples:
 	.action(handleFindTools)
 
 toolCmd
-	.command("list [connection]")
+	.command("list [connection] [prefix]")
 	.description("List tools from your connected MCP servers")
 	.option("--namespace <ns>", "Namespace to list from")
 	.option("--limit <n>", "Maximum number of tools to return (default: 10)")
@@ -809,15 +809,20 @@ toolCmd
 	.addHelpText(
 		"after",
 		`
+Arguments:
+  connection   Connection ID to list tools from (omit to list from all)
+  prefix       Only show tools whose name starts with this prefix (e.g. "issues.")
+
 Examples:
-  smithery tool list                    List tools from all connections
-  smithery tool list myserver           List tools for a specific connection
-  smithery tool list myserver --json    Output as JSON
+  smithery tool list                              List tools from all connections
+  smithery tool list myserver                     List tools for a specific connection
+  smithery tool list myserver issues.             List tools starting with "issues."
+  smithery tool list myserver issues. --json      Prefix-filtered output as JSON
 
 Tip: Use 'smithery tool find <query>' to search tools by name or intent.`,
 	)
-	.action((connection, options) =>
-		handleFindTools(undefined, { ...options, connection }),
+	.action((connection, prefix, options) =>
+		handleFindTools(undefined, { ...options, connection, prefix }),
 	)
 
 toolCmd
@@ -855,12 +860,25 @@ const eventCmd = program
 	.description("Subscribe to event streams from MCP servers")
 
 eventCmd
-	.command("topics <connection>")
+	.command("topics <connection> [prefix]")
 	.description("List available event topics for a connection")
 	.option("--namespace <ns>", "Namespace for the connection")
-	.action(async (connection: string, options: any) => {
+	.addHelpText(
+		"after",
+		`
+Arguments:
+  connection   Connection ID to list topics from
+  prefix       Only show topics whose identifier starts with this prefix (e.g. "user.")
+
+Examples:
+  smithery event topics myserver                  List all topics
+  smithery event topics myserver user.            List topics starting with "user."
+  smithery event topics myserver user. --json     Prefix-filtered output as JSON`,
+	)
+	// biome-ignore lint/suspicious/noExplicitAny: commander.js passes options as any
+	.action(async (connection: string, prefix: string | undefined, options: any) => {
 		const { listTopics } = await import("./commands/event")
-		await listTopics(connection, options)
+		await listTopics(connection, { ...options, prefix })
 	})
 
 eventCmd


### PR DESCRIPTION
## What's added in this PR?

Added optional `[prefix]` positional argument to `smithery tool list` and `smithery event topics` commands. When provided, the prefix filters results to only those whose name/identifier starts with the given prefix (case-insensitive). This enables efficient scoping for hierarchically-named tools like "issues.create", "issues.list".

### Changes:
- `smithery tool list [connection] [prefix]` - filters displayed tools by prefix
- `smithery event topics <connection> [prefix]` - filters displayed topics by prefix
- Updated CLI help text with clear argument documentation and usage examples
- Added comprehensive test cases for prefix filtering behavior

### Implementation details:
- Prefix filtering applies before pagination (existing pagination behavior unchanged when no prefix)
- Filtering is case-insensitive (consistent with existing matching behavior)
- Prefix info included in JSON output for programmatic use

## What's the issues or discussion related to this PR?

Resolves SMI-1567: Support prefix listing in CLI. Tools and event topics are often named hierarchically, and a prefix filter enables models to efficiently scope results without needing to fetch and filter everything.