### PR TITLE
feat: surface tool annotations in tool list output

### DIFF
--- a/src/commands/mcp/tool-table.ts
+++ b/src/commands/mcp/tool-table.ts
@@ -7,6 +7,7 @@ export function formatToolRow(tool: ToolInfo) {
 		connection: tool.connectionId,
 		description: tool.description ?? "",
 		inputSchema: tool.inputSchema,
+		...(tool.annotations ? { annotations: tool.annotations } : {}),
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,10 +876,12 @@ Examples:
   smithery event topics myserver user. --json     Prefix-filtered output as JSON`,
 	)
 	// biome-ignore lint/suspicious/noExplicitAny: commander.js passes options as any
-	.action(async (connection: string, prefix: string | undefined, options: any) => {
-		const { listTopics } = await import("./commands/event")
-		await listTopics(connection, { ...options, prefix })
-	})
+	.action(
+		async (connection: string, prefix: string | undefined, options: any) => {
+			const { listTopics } = await import("./commands/event")
+			await listTopics(connection, { ...options, prefix })
+		},
+	)
 
 eventCmd
 	.command("subscribe <connection> <topic> [args]")


### PR DESCRIPTION
## Summary
- Include MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) in `smithery tool list` JSON output
- One-line fix in `formatToolRow()` — annotations were already available from the MCP SDK but being stripped before output
- Enables consumers (e.g. smoke test scripts) to filter read-only vs write tools programmatically

## Test plan
- [x] `smithery tool list <connection> --limit 3` returns `annotations` field per tool
- [x] All 338 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)