### PR TITLE
fix: show error message when tool list gets invalid connection name

### DIFF
--- a/src/commands/mcp/search.ts
+++ b/src/commands/mcp/search.ts
@@ -143,13 +143,16 @@ export async function findTools(
 			const connection = await session.getConnection(options.connection)
 			connections = [connection]
 		} catch {
+			if (!isJson) {
+				console.error(pc.red(`Connection "${options.connection}" not found`))
+			}
 			outputTable({
 				data: [],
 				columns: [],
 				json: isJson,
 				jsonData: {
 					tools: [],
-					error: `Server "${options.connection}" not found`,
+					error: `Connection "${options.connection}" not found`,
 					hint: "smithery mcp list - List all connections",
 				},
 				tip: "smithery mcp list - List all connections",


### PR DESCRIPTION
### What's added in this PR?

Added a prominent red error message in text mode when `smithery tool list <name>` is called with a non-existent connection ID. Previously, the error only existed in the JSON payload and was ignored in text mode, resulting in a silent failure with just a dimmed tip.

Now when a user misspells a connection name (e.g., `betterstak` instead of `betterstack`), they see:
```
Connection "betterstak" not found
smithery mcp list - List all connections
```

### What's the issues or discussion related to this PR?

**Previous behavior**: Running `smithery tool list betterstak` (a typo) silently displayed only the dimmed tip "smithery mcp list - List all connections" with no indication the connection name was invalid.

**New behavior**: A clear red error message tells the user the connection wasn't found, making it obvious they need to check the connection name or list available connections.

This matches the existing error handling pattern used elsewhere in the codebase (e.g., `tool.ts`, `get.ts`, event commands).