### PR TITLE
fix: disable minification for shttp bundles to improve debuggability

### DIFF
--- a/src/lib/bundle/shttp.ts
+++ b/src/lib/bundle/shttp.ts
@@ -33,7 +33,7 @@ export async function buildShttpBundle(
 		outFile: moduleFile,
 		transport: "shttp",
 		production: options.production ?? true,
-		minify: true,
+		minify: false,
 		bundleMode: "user-module",
 		sourceMaps: true,
 	})


### PR DESCRIPTION
### What's added in this PR?

Disabled minification for shttp production bundles deployed as Cloudflare Workers. Deployed MCP servers now have readable code with proper variable names and formatting, making deployment errors easier to understand. Sourcemaps continue to be generated and uploaded.

### What's the issues or discussion related to this PR?

When users deploy MCP servers, crashes during deployment verification showed obfuscated error messages because the code was minified. While the CLI generated and uploaded sourcemaps to Cloudflare, CF Workers for Platforms does not automatically apply sourcemaps to error messages in deployment logs. Since this is server-side code that nobody reads, minification provided no benefit—it only made debugging harder.