### PR TITLE
fix: restore whoami behavior, metadata filtering, and flat pagination

### DIFF
--- a/skills/smithery-ai-cli/SKILL.md
+++ b/skills/smithery-ai-cli/SKILL.md
@@ -124,5 +124,5 @@ smithery auth token --policy '{
 When output is piped, Smithery commands emit JSONL (one JSON object per line):
 
 ```bash
-smithery tool list github --flat | grep label
+smithery tool list github --flat --limit 1000 | grep label
 ```

--- a/src/commands/__tests__/mcp-list.test.ts
+++ b/src/commands/__tests__/mcp-list.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockListConnections, mockCreateSession, mockOutputTable } = vi.hoisted(
+	() => {
+		const listConnections = vi.fn()
+		const createSession = vi.fn(async () => ({
+			listConnections,
+		}))
+		return {
+			mockListConnections: listConnections,
+			mockCreateSession: createSession,
+			mockOutputTable: vi.fn(),
+		}
+	},
+)
+
+vi.mock("../mcp/api", () => ({
+	ConnectSession: {
+		create: mockCreateSession,
+	},
+}))
+
+vi.mock("../../utils/output", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../utils/output")>()
+	return {
+		...actual,
+		outputTable: mockOutputTable,
+	}
+})
+
+import { setOutputMode } from "../../utils/output"
+import { listServers } from "../mcp/list"
+
+describe("mcp list command", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		setOutputMode({ json: true })
+	})
+
+	test("passes metadata filter through to connection listing", async () => {
+		mockListConnections.mockResolvedValue({
+			connections: [
+				{
+					connectionId: "github-1",
+					name: "github-1",
+					mcpUrl: "https://github.run.tools",
+					status: { state: "connected" },
+				},
+			],
+			nextCursor: null,
+		})
+
+		await listServers({
+			namespace: "prod",
+			metadata: '{"userId":"user-123"}',
+			limit: "5",
+			cursor: "cursor-1",
+		})
+
+		expect(mockCreateSession).toHaveBeenCalledWith("prod")
+		expect(mockListConnections).toHaveBeenCalledWith({
+			metadata: { userId: "user-123" },
+			limit: 5,
+			cursor: "cursor-1",
+		})
+		expect(mockOutputTable).toHaveBeenCalled()
+	})
+})

--- a/src/commands/__tests__/tools-find.test.ts
+++ b/src/commands/__tests__/tools-find.test.ts
@@ -311,11 +311,72 @@ describe("tools find command", () => {
 				jsonData: expect.objectContaining({
 					flat: true,
 					total: 2,
+					page: 1,
 					hasMore: false,
 					tools: expect.arrayContaining([
 						expect.objectContaining({ name: "experiment-get" }),
 						expect.objectContaining({ name: "experiment-results-get" }),
 					]),
+				}),
+			}),
+		)
+	})
+
+	test("paginates flat list output with --limit and --page", async () => {
+		mockGetConnection.mockResolvedValue({
+			connectionId: "github-abc",
+			name: "github-abc",
+			status: { state: "connected" },
+		})
+		mockListToolsForConnection.mockResolvedValue([
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "issues.create",
+				description: "Create issue",
+				inputSchema: { type: "object" },
+			},
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "issues.list",
+				description: "List issues",
+				inputSchema: { type: "object" },
+			},
+			{
+				connectionId: "github-abc",
+				connectionName: "github-abc",
+				name: "pulls.create",
+				description: "Create pull request",
+				inputSchema: { type: "object" },
+			},
+		])
+
+		await findTools(undefined, {
+			connection: "github-abc",
+			flat: true,
+			prefix: undefined,
+			limit: "1",
+			page: "2",
+		})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					flat: true,
+					total: 3,
+					page: 2,
+					hasMore: true,
+					tools: [
+						expect.objectContaining({
+							name: "issues.list",
+						}),
+					],
+				}),
+				pagination: expect.objectContaining({
+					page: 2,
+					hasMore: true,
+					total: 3,
 				}),
 			}),
 		)

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -23,6 +23,9 @@ export interface ToolInfo extends Tool {
 
 // Use Awaited to get the concrete type from createSmitheryClient
 type SmitheryClient = Awaited<ReturnType<typeof createSmitheryClient>>
+type ListConnectionsParams = Parameters<
+	SmitheryClient["connections"]["list"]
+>[1]
 
 /**
  * Session for Connect operations that reuses clients within a command.
@@ -54,13 +57,17 @@ export class ConnectSession {
 	async listConnections(options?: {
 		limit?: number
 		cursor?: string
+		metadata?: Record<string, unknown>
 	}): Promise<{ connections: Connection[]; nextCursor: string | null }> {
+		const metadataQuery = toMetadataQuery(options?.metadata)
+
 		// Explicit cursor: return a single page (manual pagination)
 		if (options?.cursor) {
 			const data = await this.smitheryClient.connections.list(this.namespace, {
 				limit: options.limit,
 				cursor: options.cursor,
-			})
+				...metadataQuery,
+			} as ListConnectionsParams)
 			return { connections: data.connections, nextCursor: data.nextCursor }
 		}
 
@@ -71,7 +78,8 @@ export class ConnectSession {
 		do {
 			const data = await this.smitheryClient.connections.list(this.namespace, {
 				cursor,
-			})
+				...metadataQuery,
+			} as ListConnectionsParams)
 			all.push(...data.connections)
 			cursor = data.nextCursor ?? undefined
 		} while (cursor && (!options?.limit || all.length < options.limit))
@@ -232,6 +240,18 @@ export class ConnectSession {
 			query: options?.limit ? { limit: options.limit } : undefined,
 		})
 	}
+}
+
+function toMetadataQuery(
+	metadata: Record<string, unknown> | undefined,
+): Record<string, string> {
+	if (!metadata) return {}
+	const query: Record<string, string> = {}
+	for (const [key, value] of Object.entries(metadata)) {
+		query[`metadata.${key}`] =
+			typeof value === "string" ? value : JSON.stringify(value)
+	}
+	return query
 }
 
 async function getCurrentNamespace(): Promise<string> {

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -3,15 +3,22 @@ import { fatal } from "../../lib/cli-error"
 import { readConfig } from "../../lib/client-config-io"
 import { isJsonMode, outputTable } from "../../utils/output"
 import { ConnectSession } from "./api"
+import { parseJsonObject } from "./parse-json"
 
 export async function listServers(options: {
 	namespace?: string
+	metadata?: string
 	limit?: string
 	cursor?: string
 }): Promise<void> {
 	const session = await ConnectSession.create(options.namespace)
 	const limit = options.limit ? Number.parseInt(options.limit, 10) : undefined
+	const metadata = parseJsonObject<Record<string, unknown>>(
+		options.metadata,
+		"Metadata",
+	)
 	const { connections, nextCursor } = await session.listConnections({
+		metadata,
 		limit,
 		cursor: options.cursor,
 	})

--- a/src/commands/mcp/search.ts
+++ b/src/commands/mcp/search.ts
@@ -279,8 +279,12 @@ export async function findTools(
 
 		// --flat: flatten output so `tool list --flat | grep` works naturally
 		if (options.flat) {
-			const data = candidates.map(formatListToolRow)
-			const jsonEntries = candidates.map((t) => ({
+			const total = candidates.length
+			const offset = (page - 1) * limit
+			const visibleCandidates = candidates.slice(offset, offset + limit)
+			const hasMore = offset + limit < total
+			const data = visibleCandidates.map(formatListToolRow)
+			const jsonEntries = visibleCandidates.map((t) => ({
 				type: "tool" as const,
 				name: t.name,
 				description: t.description ?? "",
@@ -295,16 +299,16 @@ export async function findTools(
 				jsonData: {
 					connection: options.connection,
 					tools: jsonEntries,
-					total: candidates.length,
+					total,
 					...(prefix ? { prefix } : {}),
 					flat: true,
-					page: 1,
-					hasMore: false,
+					page,
+					hasMore,
 					...(issues.length > 0 ? { connectionIssues: issues } : {}),
 				},
-				pagination: { total: candidates.length },
+				pagination: { page, hasMore, total },
 				tip:
-					candidates.length === 0
+					total === 0
 						? prefix
 							? `No tools found with prefix "${prefix}".`
 							: "No tools found."

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { createServer } from "node:http"
 import pc from "picocolors"
 
 const brandOrange = (text: string) => `\x1b[38;2;234;88;12m${text}\x1b[39m`
@@ -41,9 +40,9 @@ interface CliOptions {
 	configSchema?: string
 	fromBuild?: string
 	client?: string
-	server?: boolean
 	full?: boolean
 	namespace?: string
+	metadata?: string
 	agent?: string
 	global?: boolean
 	yes?: boolean
@@ -398,75 +397,21 @@ async function handleLogout() {
 }
 
 async function handleWhoami(options: CliOptions) {
-	const { createSmitheryClientSync } = await import("./lib/smithery-client")
-
-	async function mintApiKey() {
-		const rootApiKey = await getApiKey()
-		if (!rootApiKey) throw new Error("No API key found")
-		const client = createSmitheryClientSync(rootApiKey)
-		const token = await client.tokens.create({
-			policy: [
-				{
-					resources: ["connections", "servers", "namespaces", "skills"],
-					operations: ["read", "write", "execute"],
-					namespaces: "*",
-					metadata: { userId: "root-whoami" },
-					ttl: 3600,
-				},
-			],
-		})
-		const apiKey = token.token
-		const expiresAt = new Date(token.expiresAt)
-		return { apiKey, expiresAt }
-	}
 	try {
-		let { apiKey, expiresAt } = await mintApiKey()
+		const apiKey = await getApiKey()
 
 		if (!apiKey) {
-			console.log(pc.yellow("No API key found"))
+			console.log(pc.yellow("No token found"))
 			console.log(pc.gray("Run 'smithery auth login' to authenticate"))
 			process.exit(1)
-		}
-
-		if (options.server) {
-			const server = createServer(async (req, res) => {
-				res.setHeader("Access-Control-Allow-Origin", "*")
-				res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS")
-				res.setHeader("Access-Control-Allow-Headers", "Content-Type")
-
-				if (req.method === "OPTIONS") {
-					res.writeHead(204)
-					res.end()
-					return
-				}
-
-				if (req.method === "GET" && req.url === "/whoami") {
-					if (expiresAt <= new Date()) {
-						const newToken = await mintApiKey()
-						apiKey = newToken.apiKey
-						expiresAt = newToken.expiresAt
-					}
-					res.writeHead(200, { "Content-Type": "application/json" })
-					res.end(JSON.stringify({ SMITHERY_API_KEY: apiKey, expiresAt }))
-				} else {
-					res.writeHead(404, { "Content-Type": "application/json" })
-					res.end(JSON.stringify({ error: "Not found" }))
-				}
-			})
-			server.listen(4260, "localhost", () => {
-				console.log(pc.cyan("Server running at http://localhost:4260"))
-				console.log(pc.gray("GET /whoami to retrieve API key"))
-				console.log(pc.gray("Press Ctrl+C to stop"))
-			})
-			return
 		}
 
 		if (options.full) {
 			console.log(`SMITHERY_API_KEY=${apiKey}`)
 		} else {
 			const masked = `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`
-			console.log(pc.cyan("API Key:"), masked)
-			console.log(pc.gray("Use --full to display the complete key"))
+			console.log(pc.cyan("Token:"), masked)
+			console.log(pc.gray("Use --full to display the complete token"))
 		}
 	} catch (_error) {
 		console.log(pc.yellow("Not logged in"))
@@ -646,6 +591,7 @@ mcpCmd
 	.command("list")
 	.description("List your connections")
 	.option("--namespace <ns>", "Namespace to list from")
+	.option("--metadata <json>", "Filter connections by metadata as JSON object")
 	.option("--limit <n>", "Maximum number of results (default: all)")
 	.option("--cursor <cursor>", "Pagination cursor from previous response")
 	.option(
@@ -658,6 +604,7 @@ mcpCmd
 		`
 Examples:
   smithery mcp list
+  smithery mcp list --metadata '{"userId":"user-123"}'
   smithery mcp list --client claude-code
   smithery mcp list --json`,
 	)
@@ -868,7 +815,7 @@ Examples:
   smithery tool list github                           Browse root-level groups
   smithery tool list github issues.                   Drill into "issues." group
   smithery tool list github issues. --flat            All issue tools, no grouping
-  smithery tool list github --flat | grep label       Search with grep
+  smithery tool list github --flat --limit 1000 | grep label   Search with grep
 
 Use 'smithery mcp list' to see available connections.
 Use 'smithery tool find <connection> <query>' to search by name or intent.`,


### PR DESCRIPTION
## Summary
- restore `smithery auth whoami` to read-only behavior (show current key only; no token minting)
- add back `smithery mcp list --metadata <json>` and wire metadata filters through the Connect list API
- make `smithery tool list --flat` respect `--limit` and `--page` (no unlimited output)
- update examples to use bounded grep workflow (`--limit 1000`)

## Why
- `whoami` should diagnose the active auth source (env var or stored key), not mutate auth state
- agents rely on metadata filtering to find scoped connections
- flat listing should remain bounded/paginatable for safety and predictable automation

## Testing
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
