### PR TITLE
Add automation commands for deterministic MCP tool scripting

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -101,6 +101,23 @@ await esbuild.build({
 	define,
 })
 
+// Build automation SDK entry point (for programmatic usage)
+await esbuild.build({
+	entryPoints: ["src/commands/automation/context.ts"],
+	bundle: true,
+	platform: "node",
+	target: "node20",
+	format: "esm",
+	minify: true,
+	treeShaking: true,
+	outfile: "dist/automation.js",
+	external: nativePackages,
+	banner: {
+		js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+	},
+	define,
+})
+
 // Copy runtime files to dist/runtime/
 const runtimeDir = "dist/runtime"
 if (!existsSync(runtimeDir)) {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
 	"exports": {
 		".": {
 			"import": "./dist/index.js"
+		},
+		"./automation": {
+			"import": "./dist/automation.js"
 		}
 	},
 	"engines": {

--- a/skills/smithery-ai-cli/SKILL.md
+++ b/skills/smithery-ai-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smithery-ai-cli
-description: Find, connect, and use MCP tools and skills via the Smithery CLI. Use when the user searches for new tools or skills, wants to discover integrations, connect to an MCP, install a skill, or wants to interact with an external service (email, Slack, Discord, GitHub, Jira, Notion, databases, cloud APIs, monitoring, etc.).
+description: Find, connect, and use MCP tools and skills via the Smithery CLI. Use when the user searches for new tools or skills, wants to discover integrations, connect to an MCP, install a skill, create or run automations, or wants to interact with an external service (email, Slack, Discord, GitHub, Jira, Notion, databases, cloud APIs, monitoring, etc.).
 metadata: { "openclaw": { "requires": { "bins": ["smithery"] }, "homepage": "https://smithery.ai" } }
 ---
 
@@ -118,6 +118,77 @@ smithery auth token --policy '{
   "ttl": "30m"
 }'
 ```
+
+### [Automations](https://smithery.ai/docs/use/automations.md)
+
+Automations are deterministic TypeScript scripts that call MCP tools without AI.
+They live in `~/.smithery/automations/` and each file exports a `servers` array (MCP URLs) and a `run` function.
+Smithery handles connection management and auth — the automation just calls tools.
+
+Canonical flow:
+
+```bash
+# 1. Initialize the ~/.smithery project (once)
+smithery automation init
+
+# 2. Create an automation
+smithery automation create create-linear-ticket
+
+# 3. Edit ~/.smithery/automations/create-linear-ticket.ts
+#    - Add server URLs to the servers array
+#    - Implement the run function using ctx.callTool()
+
+# 4. Run it with key=value arguments
+smithery automation run create-linear-ticket ticket-name="Fix login bug" priority=high
+```
+
+Automation file structure:
+
+```typescript
+export const servers = ["https://server.smithery.ai/linear"]
+
+export async function run(
+  args: Record<string, string>,
+  ctx: {
+    callTool: (server: string, toolName: string, toolArgs: Record<string, unknown>) => Promise<unknown>
+  },
+) {
+  const result = await ctx.callTool(
+    "https://server.smithery.ai/linear",
+    "create_issue",
+    { title: args["ticket-name"], priority: args["priority"] }
+  )
+  console.log("Created:", result)
+}
+```
+
+CRUD commands: `automation create`, `automation list`, `automation get`, `automation remove`.
+On first run, connections are auto-created for each server URL. If auth is required, the CLI prints the authorization URL.
+
+### Programmatic Automations (SDK)
+
+The same automation context is available as a library import for any TypeScript project.
+Install `@smithery/cli` and import `createAutomationContext` from `@smithery/cli/automation`.
+
+```typescript
+import { createAutomationContext } from "@smithery/cli/automation"
+
+const ctx = await createAutomationContext({
+  servers: ["https://server.smithery.ai/linear"],
+  apiKey: process.env.SMITHERY_API_KEY, // or omit to use stored key
+})
+
+const result = await ctx.callTool(
+  "https://server.smithery.ai/linear",
+  "create_issue",
+  { title: "Bug: login page broken", priority: "high" },
+)
+```
+
+This works anywhere — standalone scripts, API routes, background jobs, CI pipelines, etc.
+Connections are auto-created and MCP clients are managed for you, same as the CLI.
+Pass `apiKey` explicitly (e.g. from env vars) instead of relying on `smithery auth login`.
+Auth errors throw with an `authorizationUrl` property for your code to handle.
 
 ### Piped Output
 

--- a/src/commands/automation/context.ts
+++ b/src/commands/automation/context.ts
@@ -1,0 +1,160 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import {
+	type CreateConnectionOptions,
+	createConnection as createSmitheryConnection,
+} from "@smithery/api/mcp"
+import { createSmitheryClient } from "../../lib/smithery-client"
+import { normalizeMcpUrl } from "../mcp/normalize-url"
+
+/**
+ * Context passed to automation run functions.
+ * Provides a `callTool` method that routes calls to the correct MCP connection by server URL.
+ */
+export interface AutomationContext {
+	callTool: (
+		server: string,
+		toolName: string,
+		toolArgs: Record<string, unknown>,
+	) => Promise<unknown>
+}
+
+/**
+ * Options for creating an automation context.
+ */
+export interface CreateAutomationContextOptions {
+	/** MCP server URLs to connect to. */
+	servers: string[]
+	/** Smithery API key. Falls back to SMITHERY_API_KEY env var or stored key. */
+	apiKey?: string
+	/** Smithery namespace. Falls back to stored namespace. */
+	namespace?: string
+}
+
+interface ResolvedConnection {
+	connectionId: string
+	client: Client
+}
+
+/**
+ * Create an automation context for programmatic use.
+ *
+ * Resolves MCP server URLs to Smithery connections (creating them if needed),
+ * establishes MCP clients, and returns a `callTool` function.
+ *
+ * Throws if a connection requires authorization (check error.authorizationUrl).
+ *
+ * @example
+ * ```typescript
+ * import { createAutomationContext } from "@smithery/cli/automation"
+ *
+ * const ctx = await createAutomationContext({
+ *   servers: ["https://server.smithery.ai/linear"],
+ *   apiKey: process.env.SMITHERY_API_KEY,
+ * })
+ *
+ * const result = await ctx.callTool(
+ *   "https://server.smithery.ai/linear",
+ *   "create_issue",
+ *   { title: "My ticket" },
+ * )
+ * ```
+ */
+export async function createAutomationContext(
+	options: CreateAutomationContextOptions,
+): Promise<AutomationContext> {
+	const smitheryClient = await createSmitheryClient(options.apiKey)
+
+	// Resolve namespace
+	let namespace = options.namespace
+	if (!namespace) {
+		const { getNamespace } = await import("../../utils/smithery-settings")
+		namespace = await getNamespace()
+		if (!namespace) {
+			const { namespaces } = await smitheryClient.namespaces.list()
+			if (namespaces.length === 0) {
+				const created = await smitheryClient.namespaces.create()
+				namespace = created.name
+			} else {
+				namespace = namespaces[0].name
+			}
+		}
+	}
+
+	// Resolve connections for each server URL
+	const urlToConnection = new Map<string, ResolvedConnection>()
+
+	for (const url of options.servers) {
+		const normalizedUrl = normalizeMcpUrl(url)
+
+		// Check for existing connection
+		const { connections } = await smitheryClient.connections.list(namespace, {
+			mcpUrl: normalizedUrl,
+		})
+
+		let connectionId: string
+
+		if (connections.length > 0) {
+			const conn = connections[0]
+			if (conn.status?.state === "auth_required") {
+				const authUrl = (conn.status as { authorizationUrl?: string })
+					?.authorizationUrl
+				const err = new Error(
+					`Connection for ${url} requires authorization`,
+				) as Error & { authorizationUrl?: string }
+				err.authorizationUrl = authUrl
+				throw err
+			}
+			connectionId = conn.connectionId
+		} else {
+			// Auto-create
+			const conn = await smitheryClient.connections.create(namespace, {
+				mcpUrl: normalizedUrl,
+			})
+
+			if (conn.status?.state === "auth_required") {
+				const authUrl = (conn.status as { authorizationUrl?: string })
+					?.authorizationUrl
+				const err = new Error(
+					`Connection for ${url} requires authorization`,
+				) as Error & { authorizationUrl?: string }
+				err.authorizationUrl = authUrl
+				throw err
+			}
+			connectionId = conn.connectionId
+		}
+
+		// Create MCP client
+		const { transport } = await createSmitheryConnection({
+			client: smitheryClient as unknown as CreateConnectionOptions["client"],
+			namespace,
+			connectionId,
+		})
+
+		const mcpClient = new Client({
+			name: "smithery-automation",
+			version: "1.0.0",
+		})
+		await mcpClient.connect(transport)
+
+		urlToConnection.set(url, { connectionId, client: mcpClient })
+	}
+
+	return {
+		callTool: async (
+			server: string,
+			toolName: string,
+			toolArgs: Record<string, unknown>,
+		): Promise<unknown> => {
+			const resolved = urlToConnection.get(server)
+			if (!resolved) {
+				throw new Error(
+					`Server "${server}" was not included in the servers array.`,
+				)
+			}
+			return resolved.client.callTool({
+				name: toolName,
+				arguments: toolArgs,
+			})
+		},
+	}
+}

--- a/src/commands/automation/create.ts
+++ b/src/commands/automation/create.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs"
+import pc from "picocolors"
+import { fatal } from "../../lib/cli-error"
+import { ensureInitialized } from "./ensure-init"
+import { AUTOMATIONS_DIR, automationPath } from "./paths"
+
+const TEMPLATE = (name: string) => `// Automation: ${name}
+// MCP server URLs this automation connects to
+export const servers: string[] = [
+	// e.g. "https://server.smithery.ai/linear"
+]
+
+// Run the automation deterministically — no AI, just MCP tool calls.
+export async function run(
+	args: Record<string, string>,
+	ctx: {
+		callTool: (
+			server: string,
+			toolName: string,
+			toolArgs: Record<string, unknown>,
+		) => Promise<unknown>
+	},
+): Promise<void> {
+	// Example:
+	// const result = await ctx.callTool(
+	//   "https://server.smithery.ai/linear",
+	//   "create_issue",
+	//   { title: args["ticket-name"] }
+	// )
+	// console.log(result)
+	console.log("Running ${name} with args:", args)
+}
+`
+
+export async function createAutomation(name: string): Promise<void> {
+	ensureInitialized()
+
+	const filePath = automationPath(name)
+	if (fs.existsSync(filePath)) {
+		fatal(`Automation "${name}" already exists at ${filePath}`)
+	}
+
+	fs.mkdirSync(AUTOMATIONS_DIR, { recursive: true })
+	fs.writeFileSync(filePath, TEMPLATE(name))
+
+	console.log(pc.green(`Created automation: ${name}`))
+	console.log(pc.dim(filePath))
+	console.log()
+	console.log(pc.dim("Edit the file to add your MCP servers and logic."))
+	console.log(pc.dim(`Run it with: smithery automation run ${name} key=value`))
+}

--- a/src/commands/automation/ensure-init.ts
+++ b/src/commands/automation/ensure-init.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fatal } from "../../lib/cli-error"
+import { SMITHERY_HOME } from "./paths"
+
+/** Ensure ~/.smithery has been initialized. Exits with an error if not. */
+export function ensureInitialized(): void {
+	const pkgPath = path.join(SMITHERY_HOME, "package.json")
+	if (!fs.existsSync(pkgPath)) {
+		fatal(
+			'~/.smithery is not initialized. Run "smithery automation init" first.',
+		)
+	}
+}

--- a/src/commands/automation/get.ts
+++ b/src/commands/automation/get.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs"
+import { fatal } from "../../lib/cli-error"
+import { outputDetail } from "../../utils/output"
+import { ensureInitialized } from "./ensure-init"
+import { automationPath } from "./paths"
+
+export async function getAutomation(name: string): Promise<void> {
+	ensureInitialized()
+
+	const filePath = automationPath(name)
+	if (!fs.existsSync(filePath)) {
+		fatal(`Automation "${name}" not found at ${filePath}`)
+	}
+
+	const source = fs.readFileSync(filePath, "utf-8")
+
+	outputDetail({
+		data: {
+			name,
+			path: filePath,
+			source,
+		},
+		tip: `Run it with: smithery automation run ${name} key=value`,
+	})
+}

--- a/src/commands/automation/index.ts
+++ b/src/commands/automation/index.ts
@@ -1,0 +1,11 @@
+export {
+	type AutomationContext,
+	type CreateAutomationContextOptions,
+	createAutomationContext,
+} from "./context"
+export { createAutomation } from "./create"
+export { getAutomation } from "./get"
+export { initAutomations } from "./init"
+export { listAutomations } from "./list"
+export { removeAutomation } from "./remove"
+export { runAutomation } from "./run"

--- a/src/commands/automation/init.ts
+++ b/src/commands/automation/init.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs"
+import path from "node:path"
+import pc from "picocolors"
+import { AUTOMATIONS_DIR, SMITHERY_HOME } from "./paths"
+
+const PACKAGE_JSON = {
+	name: "smithery-automations",
+	private: true,
+	type: "module",
+	dependencies: {},
+}
+
+const TSCONFIG = {
+	compilerOptions: {
+		target: "ES2022",
+		module: "ES2022",
+		moduleResolution: "bundler",
+		esModuleInterop: true,
+		strict: true,
+		skipLibCheck: true,
+	},
+}
+
+export async function initAutomations(): Promise<void> {
+	const pkgPath = path.join(SMITHERY_HOME, "package.json")
+
+	if (fs.existsSync(pkgPath)) {
+		console.log(pc.yellow("~/.smithery already initialized"))
+		return
+	}
+
+	fs.mkdirSync(AUTOMATIONS_DIR, { recursive: true })
+
+	fs.writeFileSync(pkgPath, JSON.stringify(PACKAGE_JSON, null, 2))
+	fs.writeFileSync(
+		path.join(SMITHERY_HOME, "tsconfig.json"),
+		JSON.stringify(TSCONFIG, null, 2),
+	)
+
+	console.log(pc.green("Initialized ~/.smithery"))
+	console.log(pc.dim("Created package.json, tsconfig.json, automations/"))
+}

--- a/src/commands/automation/list.ts
+++ b/src/commands/automation/list.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs"
+import path from "node:path"
+import pc from "picocolors"
+import { isJsonMode, outputTable } from "../../utils/output"
+import { ensureInitialized } from "./ensure-init"
+import { AUTOMATIONS_DIR } from "./paths"
+
+export async function listAutomations(): Promise<void> {
+	ensureInitialized()
+
+	if (!fs.existsSync(AUTOMATIONS_DIR)) {
+		if (isJsonMode()) {
+			console.log(JSON.stringify({ automations: [] }))
+		} else {
+			console.log(pc.yellow("No automations found."))
+			console.log(pc.dim("Create one with: smithery automation create <name>"))
+		}
+		return
+	}
+
+	const files = fs
+		.readdirSync(AUTOMATIONS_DIR)
+		.filter((f) => f.endsWith(".ts"))
+		.map((f) => path.basename(f, ".ts"))
+
+	if (files.length === 0) {
+		if (isJsonMode()) {
+			console.log(JSON.stringify({ automations: [] }))
+		} else {
+			console.log(pc.yellow("No automations found."))
+			console.log(pc.dim("Create one with: smithery automation create <name>"))
+		}
+		return
+	}
+
+	const data = files.map((name) => ({
+		name,
+		path: path.join(AUTOMATIONS_DIR, `${name}.ts`),
+	}))
+
+	outputTable({
+		data,
+		columns: [
+			{ key: "name", header: "NAME" },
+			{ key: "path", header: "PATH" },
+		],
+		json: isJsonMode(),
+		jsonData: { automations: data },
+		tip: "Run an automation with: smithery automation run <name> key=value",
+	})
+}

--- a/src/commands/automation/paths.ts
+++ b/src/commands/automation/paths.ts
@@ -1,0 +1,13 @@
+import os from "node:os"
+import path from "node:path"
+
+/** Root directory for the user's Smithery automations project. */
+export const SMITHERY_HOME = path.join(os.homedir(), ".smithery")
+
+/** Directory containing individual automation files. */
+export const AUTOMATIONS_DIR = path.join(SMITHERY_HOME, "automations")
+
+/** Resolve the file path for an automation by name. */
+export function automationPath(name: string): string {
+	return path.join(AUTOMATIONS_DIR, `${name}.ts`)
+}

--- a/src/commands/automation/remove.ts
+++ b/src/commands/automation/remove.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs"
+import pc from "picocolors"
+import { fatal } from "../../lib/cli-error"
+import { ensureInitialized } from "./ensure-init"
+import { automationPath } from "./paths"
+
+export async function removeAutomation(name: string): Promise<void> {
+	ensureInitialized()
+
+	const filePath = automationPath(name)
+	if (!fs.existsSync(filePath)) {
+		fatal(`Automation "${name}" not found at ${filePath}`)
+	}
+
+	fs.unlinkSync(filePath)
+	console.log(pc.green(`Removed automation: ${name}`))
+}

--- a/src/commands/automation/run.ts
+++ b/src/commands/automation/run.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs"
+import pc from "picocolors"
+import { errorMessage, fatal } from "../../lib/cli-error"
+import { isJsonMode, outputJson } from "../../utils/output"
+import { type AutomationContext, createAutomationContext } from "./context"
+import { ensureInitialized } from "./ensure-init"
+import { automationPath } from "./paths"
+
+interface AutomationModule {
+	servers: string[]
+	run: (args: Record<string, string>, ctx: AutomationContext) => Promise<void>
+}
+
+/**
+ * Parse "key=value" pairs from CLI arguments into a record.
+ */
+function parseArgs(rawArgs: string[]): Record<string, string> {
+	const result: Record<string, string> = {}
+	for (const arg of rawArgs) {
+		const eqIndex = arg.indexOf("=")
+		if (eqIndex === -1) {
+			fatal(`Invalid argument "${arg}". Expected key=value format.`)
+		}
+		const key = arg.slice(0, eqIndex)
+		const value = arg.slice(eqIndex + 1)
+		result[key] = value
+	}
+	return result
+}
+
+export async function runAutomation(
+	name: string,
+	rawArgs: string[],
+	options: { namespace?: string },
+): Promise<void> {
+	ensureInitialized()
+
+	const filePath = automationPath(name)
+	if (!fs.existsSync(filePath)) {
+		fatal(`Automation "${name}" not found at ${filePath}`)
+	}
+
+	const args = parseArgs(rawArgs)
+
+	// Dynamically import the automation file using tsx loader
+	let mod: AutomationModule
+	try {
+		mod = await import(filePath)
+	} catch (e) {
+		fatal(`Failed to load automation "${name}": ${errorMessage(e)}`)
+	}
+
+	if (!Array.isArray(mod.servers)) {
+		fatal(
+			`Automation "${name}" must export a "servers" array of MCP server URLs.`,
+		)
+	}
+	if (typeof mod.run !== "function") {
+		fatal(`Automation "${name}" must export a "run" function.`)
+	}
+
+	// Create the automation context (resolves connections, handles auth)
+	let ctx: AutomationContext
+	try {
+		ctx = await createAutomationContext({
+			servers: mod.servers,
+			namespace: options.namespace,
+		})
+	} catch (e) {
+		const err = e as Error & { authorizationUrl?: string }
+		if (err.authorizationUrl) {
+			console.error(pc.yellow(err.message))
+			console.error(pc.yellow(`Authorize at: ${err.authorizationUrl}`))
+			console.error(pc.dim("After authorizing, re-run this automation."))
+			process.exit(1)
+		}
+		fatal(`Failed to connect: ${errorMessage(e)}`)
+	}
+
+	try {
+		await mod.run(args, ctx)
+	} catch (e) {
+		if (isJsonMode()) {
+			outputJson({ error: errorMessage(e) })
+		}
+		fatal(`Automation "${name}" failed: ${errorMessage(e)}`)
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1109,6 +1109,90 @@ skillReview
 	})
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Automation command — Create and run deterministic automations
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const automationCmd = program
+	.command("automation")
+	.description("Create and run deterministic automations")
+
+automationCmd
+	.command("init")
+	.description("Initialize ~/.smithery automations project")
+	.action(async () => {
+		const { initAutomations } = await import("./commands/automation")
+		await initAutomations()
+	})
+
+automationCmd
+	.command("create <name>")
+	.description("Create a new automation")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery automation create create-linear-ticket
+  smithery automation create deploy-notification`,
+	)
+	.action(async (name) => {
+		const { createAutomation } = await import("./commands/automation")
+		await createAutomation(name)
+	})
+
+automationCmd
+	.command("list")
+	.description("List all automations")
+	.action(async () => {
+		const { listAutomations } = await import("./commands/automation")
+		await listAutomations()
+	})
+
+automationCmd
+	.command("get <name>")
+	.description("Show automation details and source")
+	.action(async (name) => {
+		const { getAutomation } = await import("./commands/automation")
+		await getAutomation(name)
+	})
+
+const automationRemoveCmd = automationCmd
+	.command("remove <name>")
+	.description("Delete an automation")
+	.action(async (name) => {
+		const { removeAutomation } = await import("./commands/automation")
+		await removeAutomation(name)
+	})
+
+registerAlias(
+	automationCmd,
+	"rm <name>",
+	automationRemoveCmd,
+	async (name: string) => {
+		const { removeAutomation } = await import("./commands/automation")
+		await removeAutomation(name)
+	},
+)
+
+automationCmd
+	.command("run <name> [args...]")
+	.description("Run an automation with key=value arguments")
+	.option("--namespace <ns>", "Namespace for connections")
+	.addHelpText(
+		"after",
+		`
+Arguments are passed as key=value pairs:
+  smithery automation run create-linear-ticket ticket-name="my ticket" priority=high
+
+Examples:
+  smithery automation run create-linear-ticket ticket-name="Fix login bug"
+  smithery automation run deploy-notification env=production version=1.2.3`,
+	)
+	.action(async (name, args, options) => {
+		const { runAutomation } = await import("./commands/automation")
+		await runAutomation(name, args, options)
+	})
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Auth command — Authentication and permissions
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1198,6 +1282,10 @@ and combine with rpcReqMatch to also restrict which tools can be called (as show
 		const { createToken } = await import("./commands/auth/token")
 		await createToken(options)
 	})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Automation command — Create and run deterministic MCP automations
+// ═══════════════════════════════════════════════════════════════════════════════
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Management
@@ -1336,6 +1424,7 @@ const COMMAND_ALIASES: Record<string, string> = {
 	tools: "tool",
 	skills: "skill",
 	events: "event",
+	automations: "automation",
 }
 const argv = process.argv.slice()
 if (argv[2] && argv[2] in COMMAND_ALIASES) {


### PR DESCRIPTION
## Summary
- Add `smithery automation` command group (`init`, `create`, `list`, `get`, `remove`, `run`) for creating and running deterministic TypeScript scripts that call MCP tools without AI
- Automations live in `~/.smithery/automations/`, export a `servers` array and a `run` function, and receive a `callTool` context for making MCP tool calls
- Expose `createAutomationContext` as a programmatic SDK entry point via `@smithery/cli/automation` for use in standalone scripts, API routes, CI pipelines, etc.
- Update build to produce `dist/automation.js` bundle and add `./automation` package export

## Test plan
- [ ] Run `smithery automation init` — verify `~/.smithery/package.json` and `tsconfig.json` are created
- [ ] Run `smithery automation create test-auto` — verify template file created at `~/.smithery/automations/test-auto.ts`
- [ ] Run `smithery automation list` — verify it shows the created automation
- [ ] Run `smithery automation get test-auto` — verify it prints source and metadata
- [ ] Run `smithery automation remove test-auto` — verify file is deleted
- [ ] Run `smithery automation run <name> key=value` with a real MCP server — verify tool calls execute
- [ ] Verify `pnpm run build` succeeds with the new esbuild entry point
- [ ] Verify JSONL output mode works for `list` and `get` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)