### PR TITLE
feat: Discord community invite after install

### DIFF
--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -1,5 +1,7 @@
 import pc from "picocolors"
 import { fatal } from "../../lib/cli-error"
+import { trackEvent } from "../../utils/analytics"
+import { showDiscordInvite } from "../../utils/discord"
 import { outputDetail } from "../../utils/output"
 import { ConnectSession } from "./api"
 import { formatConnectionOutput } from "./format-connection"
@@ -85,6 +87,9 @@ export async function addServer(
 			data: output,
 			tip: `Call tools: smithery tool call ${id} <tool> '<args>'\nList tools: smithery tool list ${id}`,
 		})
+
+		showDiscordInvite()
+		trackEvent("discord_invite_shown", { source: "mcp_add" })
 	} catch (error) {
 		fatal("Failed to add connection", error)
 	}

--- a/src/commands/mcp/install.ts
+++ b/src/commands/mcp/install.ts
@@ -14,9 +14,10 @@ import { saveConfig } from "../../lib/keychain"
 import { verbose } from "../../lib/logger"
 import { resolveServer } from "../../lib/registry"
 import type { ServerConfig } from "../../types/registry"
-import { checkAnalyticsConsent } from "../../utils/analytics"
+import { checkAnalyticsConsent, trackEvent } from "../../utils/analytics"
 import { parseQualifiedName } from "../../utils/cli-utils"
 import { promptForRestart, showPostInstallHint } from "../../utils/client"
+import { showDiscordInvite } from "../../utils/discord"
 import { resolveTransport } from "../../utils/install/transport"
 import { resolveUserConfig } from "../../utils/install/user-config"
 import {
@@ -120,6 +121,8 @@ export async function installServer(
 		console.log(
 			pc.green(`✓ ${qualifiedName} successfully installed for ${client}`),
 		)
+		showDiscordInvite()
+		trackEvent("discord_invite_shown", { source: "mcp_install", client })
 		showPostInstallHint(client)
 		await promptForRestart(client)
 		process.exit(0)

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -1,5 +1,7 @@
 import pc from "picocolors"
 import { fatal } from "../../lib/cli-error"
+import { trackEvent } from "../../utils/analytics"
+import { showDiscordInvite } from "../../utils/discord"
 import {
 	createPublicSkillsClient,
 	getSkillUrl,
@@ -65,4 +67,7 @@ export async function installSkill(
 	console.log(pc.cyan(`Running: ${command}`))
 	console.log()
 	execSync(command, { stdio: "inherit" })
+
+	showDiscordInvite()
+	trackEvent("discord_invite_shown", { source: "skill_install" })
 }

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -2,9 +2,12 @@ import pc from "picocolors"
 
 export const DISCORD_INVITE_URL = "https://discord.gg/sKd9uycgH9"
 
+// Discord brand color "blurple" (#5865F2) as ANSI 256-color escape
+const blurple = (text: string) => `\x1b[38;2;88;101;242m${text}\x1b[39m`
+
 export function showDiscordInvite() {
 	console.log()
 	console.log(
-		pc.dim("Join the Smithery community: ") + pc.cyan(DISCORD_INVITE_URL),
+		pc.dim("Join the Smithery community: ") + blurple(DISCORD_INVITE_URL),
 	)
 }

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,0 +1,10 @@
+import pc from "picocolors"
+
+export const DISCORD_INVITE_URL = "https://discord.gg/sKd9uycgH9"
+
+export function showDiscordInvite() {
+	console.log()
+	console.log(
+		pc.dim("Join the Smithery community: ") + pc.cyan(DISCORD_INVITE_URL),
+	)
+}


### PR DESCRIPTION
## Summary
- Show Discord community invite link after successful `mcp add`, `mcp install`, and `skill install` commands
- Fire `discord_invite_shown` analytics event with source context
- New `src/utils/discord.ts` utility with shared invite URL and display function

Part of SMI-1598. Web changes in smithery-ai/mono#1755.

## Test plan
- [ ] Run `smithery mcp add <server>` — verify Discord invite line appears after connection output
- [ ] Run `smithery mcp install <server> --client claude` — verify invite appears after success message
- [ ] Run `smithery skill add <skill>` — verify invite appears after skill install

🤖 Generated with [Claude Code](https://claude.com/claude-code)