### PR TITLE
fix: detect non-interactive shells in auth login and publish

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,15 @@ async function handleSecretsDelete(server: string, name: string) {
 }
 
 async function handleLogin() {
+	if (!process.stdin.isTTY) {
+		console.error(
+			pc.red(
+				"Error: This command requires an interactive terminal. Run it directly in your terminal.",
+			),
+		)
+		process.exit(1)
+	}
+
 	const { executeCliAuthFlow } = await import("./lib/cli-auth")
 	const { validateApiKey } = await import("./lib/registry")
 

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -282,8 +282,16 @@ export async function ensureApiKey(apiKey?: string): Promise<string> {
 		existingApiKey = await getApiKey()
 	}
 
-	// If no API key found, prompt for one and set it as existing
+	// If no API key found, check for interactive terminal before prompting
 	if (!existingApiKey) {
+		if (!process.stdin.isTTY) {
+			console.error(
+				pc.red(
+					"Not authenticated. Run `smithery auth login` in your terminal first.",
+				),
+			)
+			process.exit(1)
+		}
 		const promptedApiKey = await promptForApiKey()
 		await setApiKey(promptedApiKey)
 		existingApiKey = promptedApiKey
@@ -299,13 +307,23 @@ export async function ensureApiKey(apiKey?: string): Promise<string> {
 		if (error instanceof AuthenticationError) {
 			console.error(
 				pc.red(
-					'✗ API key is expired or invalid. Run "smithery login" to re-authenticate.',
+					'✗ API key is expired or invalid. Run "smithery auth login" to re-authenticate.',
 				),
 			)
 
 			// Clear invalid saved key if it was from config (not command line)
 			if (!apiKey) {
 				await clearApiKey()
+			}
+
+			// In non-interactive mode, exit instead of prompting
+			if (!process.stdin.isTTY) {
+				console.error(
+					pc.red(
+						"Not authenticated. Run `smithery auth login` in your terminal first.",
+					),
+				)
+				process.exit(1)
 			}
 
 			// Prompt for new API key, validate, and save


### PR DESCRIPTION
## Summary
- **`smithery auth login`**: Detects non-interactive shells (`!process.stdin.isTTY`) and exits with a clear error message instead of hanging while waiting for an OAuth browser callback that will never arrive.
- **`smithery mcp publish` / `ensureApiKey`**: When no API key is found and the shell is non-interactive, exits with an actionable error ("Run `smithery auth login` in your terminal first") instead of hanging on an inquirer prompt. Same behavior when an existing key is invalid.
- Also fixes the error message to reference `smithery auth login` (was `smithery login`).

## Test plan
- [x] All 366 existing tests pass
- [ ] Manual: run `echo | smithery auth login` — should print error and exit immediately
- [ ] Manual: unset SMITHERY_API_KEY and run `echo | smithery mcp publish --name test` — should print auth error and exit
- [ ] Manual: `smithery auth login` in a real terminal still works as before

Fixes SMI-1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)