### PR TITLE
feat(SMI-1688): support input_required MCP connection flows

### DIFF
--- a/src/commands/__tests__/add-flow.test.ts
+++ b/src/commands/__tests__/add-flow.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockPromptForConnectionInputs } = vi.hoisted(() => ({
+	mockPromptForConnectionInputs: vi.fn(),
+}))
+
+vi.mock("../../utils/command-prompts", () => ({
+	promptForConnectionInputs: mockPromptForConnectionInputs,
+}))
+
+import { setOutputMode } from "../../utils/output"
+import {
+	buildDuplicateInputRequiredTip,
+	finalizeAddedConnection,
+} from "../mcp/add-flow"
+
+describe("add flow", () => {
+	const originalStdinTTY = process.stdin.isTTY
+	const originalStdoutTTY = process.stdout.isTTY
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		setOutputMode({ table: true })
+		process.stdin.isTTY = true
+		process.stdout.isTTY = true
+	})
+
+	afterEach(() => {
+		setOutputMode({})
+		process.stdin.isTTY = originalStdinTTY
+		process.stdout.isTTY = originalStdoutTTY
+	})
+
+	test("prompts for missing inputs and updates the same connection until stable", async () => {
+		mockPromptForConnectionInputs.mockResolvedValue({
+			headers: { "x-api-key": "secret-123" },
+			query: { projectId: "proj-123" },
+		})
+
+		const session = {
+			setConnection: vi.fn().mockResolvedValue({
+				connectionId: "test-input-required-two",
+				name: "test-input-required-two",
+				mcpUrl:
+					"https://server.smithery.ai/calclavia/test-input-required-two?projectId=proj-123",
+				metadata: null,
+				status: {
+					state: "auth_required",
+					authorizationUrl: "https://example.com/oauth",
+				},
+			}),
+		}
+
+		const connection = await finalizeAddedConnection(
+			session as never,
+			{
+				connectionId: "test-input-required-two",
+				name: "test-input-required-two",
+				mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+				metadata: null,
+				status: {
+					state: "input_required",
+					http: {
+						headers: {
+							"x-api-key": {
+								label: "API Key",
+								description: "Manual test header",
+								required: true,
+							},
+						},
+						query: {
+							projectId: {
+								label: "Project ID",
+								description: "Manual test query",
+								required: true,
+							},
+						},
+					},
+					missing: {
+						headers: ["x-api-key"],
+						query: ["projectId"],
+					},
+				},
+			} as never,
+			{
+				name: "test-input-required-two",
+			},
+		)
+
+		expect(mockPromptForConnectionInputs).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: "input_required",
+			}),
+		)
+		expect(session.setConnection).toHaveBeenCalledWith(
+			"test-input-required-two",
+			"https://server.smithery.ai/calclavia/test-input-required-two?projectId=proj-123",
+			expect.objectContaining({
+				name: "test-input-required-two",
+				headers: { "x-api-key": "secret-123" },
+			}),
+		)
+		expect(connection.status).toEqual({
+			state: "auth_required",
+			authorizationUrl: "https://example.com/oauth",
+		})
+	})
+
+	test("returns unresolved connection unchanged in json mode", async () => {
+		setOutputMode({ json: true })
+
+		const session = {
+			setConnection: vi.fn(),
+		}
+		const connection = {
+			connectionId: "test-input-required-two",
+			name: "test-input-required-two",
+			mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+			metadata: null,
+			status: {
+				state: "input_required",
+				http: {},
+				missing: {
+					headers: [],
+					query: ["projectId"],
+				},
+			},
+		}
+
+		const result = await finalizeAddedConnection(
+			session as never,
+			connection as never,
+			{},
+		)
+
+		expect(mockPromptForConnectionInputs).not.toHaveBeenCalled()
+		expect(session.setConnection).not.toHaveBeenCalled()
+		expect(result).toBe(connection)
+	})
+
+	test("builds a remove and re-add hint for unresolved duplicates", () => {
+		const tip = buildDuplicateInputRequiredTip({
+			connectionId: "test-input-required-two",
+			name: "test-input-required-two",
+			mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+			metadata: null,
+			status: {
+				state: "input_required",
+				http: {
+					headers: {
+						"x-api-key": {
+							label: "API Key",
+							required: true,
+						},
+					},
+					query: {
+						projectId: {
+							label: "Project ID",
+							required: true,
+						},
+					},
+				},
+				missing: {
+					headers: ["x-api-key"],
+					query: ["projectId"],
+				},
+			},
+		} as never)
+
+		expect(tip).toContain("smithery mcp remove test-input-required-two")
+		expect(tip).toContain(
+			"smithery mcp add 'https://server.smithery.ai/calclavia/test-input-required-two?projectId=...'",
+		)
+		expect(tip).toContain(`--headers '{"x-api-key":"..."}'`)
+	})
+})

--- a/src/commands/__tests__/format-connection.test.ts
+++ b/src/commands/__tests__/format-connection.test.ts
@@ -37,4 +37,17 @@ describe("formatConnectionOutput", () => {
 
 		expect(output.status).toEqual(status)
 	})
+
+	test("does not expose iconUrl in CLI output", () => {
+		const output = formatConnectionOutput({
+			connectionId: "browserbase",
+			name: "browserbase",
+			mcpUrl: "https://server.smithery.ai/browserbase",
+			metadata: null,
+			status: { state: "connected" },
+			iconUrl: "https://icons.duckduckgo.com/ip3/www.browserbase.com.ico",
+		} as never)
+
+		expect(output.iconUrl).toBeUndefined()
+	})
 })

--- a/src/commands/__tests__/format-connection.test.ts
+++ b/src/commands/__tests__/format-connection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest"
+import { formatConnectionOutput } from "../mcp/format-connection"
+
+describe("formatConnectionOutput", () => {
+	test("preserves input_required status payload", () => {
+		const status = {
+			state: "input_required" as const,
+			http: {
+				headers: {
+					"x-api-key": {
+						label: "API Key",
+						description: "Manual test header",
+						required: true,
+					},
+				},
+				query: {
+					projectId: {
+						label: "Project ID",
+						description: "Manual test query",
+						required: true,
+					},
+				},
+			},
+			missing: {
+				headers: ["x-api-key"],
+				query: ["projectId"],
+			},
+		}
+
+		const output = formatConnectionOutput({
+			connectionId: "test-input-required-two",
+			name: "test-input-required-two",
+			mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+			metadata: null,
+			status,
+		} as never)
+
+		expect(output.status).toEqual(status)
+	})
+})

--- a/src/commands/__tests__/mcp-add-impl.test.ts
+++ b/src/commands/__tests__/mcp-add-impl.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+	mockListConnectionsByUrl,
+	mockCreateConnection,
+	mockCreateSession,
+	mockOutputConnectionDetail,
+} = vi.hoisted(() => {
+	const listConnectionsByUrl = vi.fn()
+	const createConnection = vi.fn()
+	const createSession = vi.fn(async () => ({
+		listConnectionsByUrl,
+		createConnection,
+	}))
+
+	return {
+		mockListConnectionsByUrl: listConnectionsByUrl,
+		mockCreateConnection: createConnection,
+		mockCreateSession: createSession,
+		mockOutputConnectionDetail: vi.fn(),
+	}
+})
+
+vi.mock("../mcp/api", () => ({
+	ConnectSession: {
+		create: mockCreateSession,
+	},
+}))
+
+vi.mock("../mcp/output-connection", () => ({
+	outputConnectionDetail: mockOutputConnectionDetail,
+}))
+
+import { addServer } from "../mcp/add-impl"
+
+describe("mcp add duplicate handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	test("shows a remove and re-add hint for unresolved duplicate connections", async () => {
+		mockListConnectionsByUrl.mockResolvedValue({
+			connections: [
+				{
+					connectionId: "test-input-required-two",
+					name: "test-input-required-two",
+					mcpUrl:
+						"https://server.smithery.ai/calclavia/test-input-required-two",
+					metadata: null,
+					status: {
+						state: "input_required",
+						http: {
+							headers: {
+								"x-api-key": {
+									label: "API Key",
+									required: true,
+								},
+							},
+							query: {
+								projectId: {
+									label: "Project ID",
+									required: true,
+								},
+							},
+						},
+						missing: {
+							headers: ["x-api-key"],
+							query: ["projectId"],
+						},
+					},
+				},
+			],
+		})
+
+		await addServer("calclavia/test-input-required-two", {})
+
+		expect(mockCreateConnection).not.toHaveBeenCalled()
+		expect(mockOutputConnectionDetail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				connection: expect.objectContaining({
+					connectionId: "test-input-required-two",
+				}),
+				tip: expect.stringContaining(
+					"smithery mcp remove test-input-required-two",
+				),
+			}),
+		)
+	})
+})

--- a/src/commands/__tests__/mcp-list.test.ts
+++ b/src/commands/__tests__/mcp-list.test.ts
@@ -65,4 +65,37 @@ describe("mcp list command", () => {
 		})
 		expect(mockOutputTable).toHaveBeenCalled()
 	})
+
+	test("preserves input_required status in output rows", async () => {
+		mockListConnections.mockResolvedValue({
+			connections: [
+				{
+					connectionId: "test-input-required-two",
+					name: "test-input-required-two",
+					mcpUrl:
+						"https://server.smithery.ai/calclavia/test-input-required-two",
+					status: {
+						state: "input_required",
+						http: {},
+						missing: { headers: ["x-api-key"], query: ["projectId"] },
+					},
+				},
+			],
+			nextCursor: null,
+		})
+
+		await listServers({})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					servers: [
+						expect.objectContaining({
+							status: "input_required",
+						}),
+					],
+				}),
+			}),
+		)
+	})
 })

--- a/src/commands/__tests__/output-connection.test.ts
+++ b/src/commands/__tests__/output-connection.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { setOutputMode } from "../../utils/output"
+import { outputConnectionDetail } from "../mcp/output-connection"
+
+describe("outputConnectionDetail", () => {
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		setOutputMode({ table: true })
+	})
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore()
+		setOutputMode({})
+	})
+
+	test("renders missing headers and query params for input_required connections", () => {
+		outputConnectionDetail({
+			connection: {
+				connectionId: "test-input-required-two",
+				name: "test-input-required-two",
+				mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+				metadata: null,
+				status: {
+					state: "input_required",
+					http: {
+						headers: {
+							"x-api-key": {
+								label: "API Key",
+								description: "Manual test header",
+								required: true,
+							},
+						},
+						query: {
+							projectId: {
+								label: "Project ID",
+								description: "Manual test query",
+								required: true,
+							},
+						},
+					},
+					missing: {
+						headers: ["x-api-key"],
+						query: ["projectId"],
+					},
+				},
+			} as never,
+		})
+
+		const lines = consoleLogSpy.mock.calls.map(([line]) => String(line))
+		expect(lines).toContainEqual(expect.stringContaining("Missing headers:"))
+		expect(lines).toContainEqual(expect.stringContaining("x-api-key"))
+		expect(lines).toContainEqual(expect.stringContaining("Manual test header"))
+		expect(lines).toContainEqual(
+			expect.stringContaining("Missing query params:"),
+		)
+		expect(lines).toContainEqual(expect.stringContaining("projectId"))
+		expect(lines).toContainEqual(expect.stringContaining("Manual test query"))
+	})
+})

--- a/src/commands/__tests__/tools-find.test.ts
+++ b/src/commands/__tests__/tools-find.test.ts
@@ -381,4 +381,52 @@ describe("tools find command", () => {
 			}),
 		)
 	})
+
+	test("reports input_required connections as connection issues", async () => {
+		mockGetConnection.mockResolvedValue({
+			connectionId: "test-input-required-two",
+			name: "test-input-required-two",
+			mcpUrl: "https://server.smithery.ai/calclavia/test-input-required-two",
+			status: {
+				state: "input_required",
+				http: {
+					headers: {
+						"x-api-key": {
+							label: "API Key",
+							required: true,
+						},
+					},
+				},
+				missing: {
+					headers: ["x-api-key"],
+					query: [],
+				},
+			},
+		})
+		mockListToolsForConnection.mockRejectedValue(
+			new Error("connection requires additional input"),
+		)
+
+		await findTools(undefined, {
+			connection: "test-input-required-two",
+			prefix: undefined,
+		})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					tools: [],
+					connectionIssues: [
+						expect.objectContaining({
+							error:
+								'Server "test-input-required-two" requires additional input',
+							status: expect.objectContaining({
+								state: "input_required",
+							}),
+						}),
+					],
+				}),
+			}),
+		)
+	})
 })

--- a/src/commands/mcp/add-flow.ts
+++ b/src/commands/mcp/add-flow.ts
@@ -1,0 +1,57 @@
+import { promptForConnectionInputs } from "../../utils/command-prompts"
+import { isJsonMode } from "../../utils/output"
+import type { Connection, ConnectSession } from "./api"
+import {
+	buildInputRequiredAddCommand,
+	isInputRequiredStatus,
+	rewriteConnectionUrl,
+} from "./connection-status"
+
+export async function finalizeAddedConnection(
+	session: ConnectSession,
+	connection: Connection,
+	options: {
+		name?: string
+		metadata?: Record<string, unknown>
+		headers?: Record<string, string>
+		unstableWebhookUrl?: string
+	},
+): Promise<Connection> {
+	let current = connection
+	let currentUrl = connection.mcpUrl
+	let headers = { ...(options.headers ?? {}) }
+
+	while (
+		isInputRequiredStatus(current.status) &&
+		process.stdin.isTTY &&
+		process.stdout.isTTY &&
+		!isJsonMode()
+	) {
+		const input = await promptForConnectionInputs(current.status)
+		headers = { ...headers, ...(input.headers ?? {}) }
+		currentUrl = rewriteConnectionUrl(currentUrl, input.query)
+		current = await session.setConnection(current.connectionId, currentUrl, {
+			name: options.name,
+			metadata: options.metadata,
+			headers: Object.keys(headers).length > 0 ? headers : undefined,
+			unstableWebhookUrl: options.unstableWebhookUrl,
+		})
+		currentUrl = current.mcpUrl
+	}
+
+	return current
+}
+
+export function buildDuplicateInputRequiredTip(
+	connection: Connection,
+): string | undefined {
+	if (!isInputRequiredStatus(connection.status)) {
+		return undefined
+	}
+
+	return [
+		"Remove and re-add to continue:",
+		`smithery mcp remove ${connection.connectionId}`,
+		buildInputRequiredAddCommand(connection.mcpUrl, connection.status),
+	].join("\n")
+}

--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -1,5 +1,9 @@
 import pc from "picocolors"
 import { fatal } from "../../lib/cli-error"
+import {
+	buildDuplicateInputRequiredTip,
+	finalizeAddedConnection,
+} from "./add-flow"
 import { ConnectSession } from "./api"
 import { normalizeMcpUrl } from "./normalize-url"
 import { outputConnectionDetail } from "./output-connection"
@@ -54,8 +58,17 @@ export async function addServer(
 						),
 					)
 				}
-				console.error(pc.dim(`Use --force to create a new connection anyway.`))
-				outputConnectionDetail({ connection: match })
+				const tip =
+					buildDuplicateInputRequiredTip(match) ??
+					(status === "connected"
+						? `Use smithery tool list ${match.connectionId} to interact with it.`
+						: status === "auth_required"
+							? "Use the authorization URL above to complete setup."
+							: `Use --force to create a new connection anyway.`)
+				outputConnectionDetail({
+					connection: match,
+					tip,
+				})
 				return
 			}
 		}
@@ -67,8 +80,15 @@ export async function addServer(
 			unstableWebhookUrl: options.unstableWebhookUrl,
 		})
 
-		if (connection.status?.state === "auth_required") {
-			const authUrl = (connection.status as { authorizationUrl?: string })
+		const finalConnection = await finalizeAddedConnection(session, connection, {
+			name: options.name,
+			metadata: parsedMetadata,
+			headers: parsedHeaders,
+			unstableWebhookUrl: options.unstableWebhookUrl,
+		})
+
+		if (finalConnection.status?.state === "auth_required") {
+			const authUrl = (finalConnection.status as { authorizationUrl?: string })
 				?.authorizationUrl
 			if (authUrl) {
 				console.error(
@@ -77,9 +97,9 @@ export async function addServer(
 			}
 		}
 
-		const id = connection.connectionId
+		const id = finalConnection.connectionId
 		outputConnectionDetail({
-			connection,
+			connection: finalConnection,
 			tip: `Call tools: smithery tool call ${id} <tool> '<args>'\nList tools: smithery tool list ${id}`,
 		})
 	} catch (error) {

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -1,4 +1,5 @@
 import { fatal } from "../../lib/cli-error"
+import { finalizeAddedConnection } from "./add-flow"
 import { addServer as addServerImpl } from "./add-impl"
 import { ConnectSession } from "./api"
 import { normalizeMcpUrl } from "./normalize-url"
@@ -39,9 +40,19 @@ export async function addServer(
 					unstableWebhookUrl: options.unstableWebhookUrl,
 				},
 			)
-			outputConnectionDetail({
+			const finalConnection = await finalizeAddedConnection(
+				session,
 				connection,
-				tip: `Use smithery tool list ${connection.connectionId} to view tools.`,
+				{
+					name,
+					metadata: parsedMetadata,
+					headers: parsedHeaders,
+					unstableWebhookUrl: options.unstableWebhookUrl,
+				},
+			)
+			outputConnectionDetail({
+				connection: finalConnection,
+				tip: `Use smithery tool list ${finalConnection.connectionId} to view tools.`,
 			})
 		} catch (error) {
 			fatal("Failed to add connection", error)

--- a/src/commands/mcp/connection-status.ts
+++ b/src/commands/mcp/connection-status.ts
@@ -1,0 +1,49 @@
+import type { Connection as SmitheryConnection } from "@smithery/api/resources/connections/connections.js"
+
+export type ConnectionStatusInputRequired =
+	SmitheryConnection.ConnectionStatusInputRequired
+
+export type ConnectionInputField =
+	| SmitheryConnection.ConnectionStatusInputRequired.HTTP.Headers
+	| SmitheryConnection.ConnectionStatusInputRequired.HTTP.Query
+
+export function isInputRequiredStatus(
+	status: { state?: string } | null | undefined,
+): status is ConnectionStatusInputRequired {
+	return status?.state === "input_required"
+}
+
+export function rewriteConnectionUrl(
+	mcpUrl: string,
+	query: Record<string, string> | undefined,
+): string {
+	if (!query || Object.keys(query).length === 0) {
+		return mcpUrl
+	}
+
+	const url = new URL(mcpUrl)
+	for (const [key, value] of Object.entries(query)) {
+		url.searchParams.set(key, value)
+	}
+	return url.toString()
+}
+
+export function buildInputRequiredAddCommand(
+	mcpUrl: string,
+	status: ConnectionStatusInputRequired,
+): string {
+	const url = rewriteConnectionUrl(
+		mcpUrl,
+		Object.fromEntries(status.missing.query.map((key) => [key, "..."])),
+	)
+	const headers = Object.fromEntries(
+		status.missing.headers.map((key) => [key, "..."]),
+	)
+
+	const parts = [`smithery mcp add '${url}'`]
+	if (Object.keys(headers).length > 0) {
+		parts.push(`--headers '${JSON.stringify(headers)}'`)
+	}
+
+	return parts.join(" ")
+}

--- a/src/commands/mcp/format-connection.ts
+++ b/src/commands/mcp/format-connection.ts
@@ -27,10 +27,6 @@ export function formatConnectionOutput(
 		output.serverInfo = formatServerInfo(connection.serverInfo)
 	}
 
-	if (connection.iconUrl) {
-		output.iconUrl = connection.iconUrl
-	}
-
 	return output
 }
 

--- a/src/commands/mcp/format-connection.ts
+++ b/src/commands/mcp/format-connection.ts
@@ -1,4 +1,5 @@
 import type { Connection } from "./api"
+import { isInputRequiredStatus } from "./connection-status"
 
 /**
  * Format a Connection object for output, including all relevant fields.
@@ -56,6 +57,12 @@ function formatStatus(
 		return {
 			state: "error",
 			message: status.message,
+		}
+	}
+
+	if (isInputRequiredStatus(status)) {
+		return {
+			...status,
 		}
 	}
 

--- a/src/commands/mcp/output-connection.ts
+++ b/src/commands/mcp/output-connection.ts
@@ -1,5 +1,10 @@
-import { outputDetail } from "../../utils/output"
+import pc from "picocolors"
+import { isJsonMode, outputDetail } from "../../utils/output"
 import type { Connection } from "./api"
+import {
+	type ConnectionInputField,
+	isInputRequiredStatus,
+} from "./connection-status"
 import { formatConnectionOutput } from "./format-connection"
 
 export function outputConnectionDetail(options: {
@@ -8,8 +13,61 @@ export function outputConnectionDetail(options: {
 }): void {
 	const { connection, tip } = options
 
-	outputDetail({
-		data: formatConnectionOutput(connection),
-		tip,
-	})
+	if (isJsonMode() || !isInputRequiredStatus(connection.status)) {
+		outputDetail({
+			data: formatConnectionOutput(connection),
+			tip,
+		})
+		return
+	}
+
+	const rows = [
+		["connectionId", connection.connectionId],
+		["name", connection.name],
+		["mcpUrl", connection.mcpUrl],
+		["status", connection.status.state],
+	]
+	const maxKeyLen = Math.max(...rows.map(([key]) => key.length))
+
+	for (const [key, value] of rows) {
+		console.log(`${pc.dim(key.padEnd(maxKeyLen))}  ${value}`)
+	}
+
+	printMissingFields(
+		"Missing headers:",
+		connection.status.missing.headers,
+		connection.status.http.headers,
+	)
+	printMissingFields(
+		"Missing query params:",
+		connection.status.missing.query,
+		connection.status.http.query,
+	)
+
+	if (tip) {
+		console.log()
+		console.log(pc.dim(`Tip: ${tip}`))
+	}
+}
+
+function printMissingFields(
+	title: string,
+	keys: string[],
+	fields: Record<string, ConnectionInputField> | undefined,
+): void {
+	if (keys.length === 0) {
+		return
+	}
+
+	console.log()
+	console.log(title)
+
+	const maxKeyLen = Math.max(...keys.map((key) => key.length))
+	for (const key of keys) {
+		const field = fields?.[key]
+		console.log(`  ${key.padEnd(maxKeyLen)}  ${field?.label ?? key}`)
+		if (field?.description) {
+			console.log(pc.dim(`    ${field.description}`))
+		}
+	}
 }

--- a/src/commands/mcp/search.ts
+++ b/src/commands/mcp/search.ts
@@ -2,6 +2,7 @@ import FlexSearch from "flexsearch"
 import pc from "picocolors"
 import { isJsonMode, outputJson, outputTable } from "../../utils/output"
 import { type Connection, ConnectSession, type ToolInfo } from "./api"
+import { isInputRequiredStatus } from "./connection-status"
 import {
 	formatGroupRow,
 	formatListToolRow,
@@ -39,6 +40,15 @@ function formatConnectionStatus(
 		return {
 			error: `Server "${connection.name}" has an error: ${connection.status.message}`,
 			status: { state: "error", message: connection.status.message },
+		}
+	}
+
+	if (isInputRequiredStatus(connection.status)) {
+		return {
+			error: `Server "${connection.name}" requires additional input`,
+			status: {
+				...connection.status,
+			},
 		}
 	}
 

--- a/src/utils/command-prompts.ts
+++ b/src/utils/command-prompts.ts
@@ -1,4 +1,5 @@
 import pc from "picocolors"
+import type { ConnectionStatusInputRequired } from "../commands/mcp/connection-status"
 import { VALID_CLIENTS, type ValidClient } from "../config/clients"
 import { fatal } from "../lib/cli-error"
 import { searchServers } from "../lib/registry"
@@ -545,4 +546,67 @@ export async function promptForServerNameInput(
 	])
 
 	return serverName.trim()
+}
+
+export async function promptForConnectionInputs(
+	status: ConnectionStatusInputRequired,
+): Promise<{
+	headers?: Record<string, string>
+	query?: Record<string, string>
+}> {
+	const inquirer = (await import("inquirer")).default
+	const prompts = [
+		...status.missing.headers.map((key) => ({
+			type: "password",
+			name: `header:${key}`,
+			mask: "*",
+			message: formatMissingInputMessage(
+				"header",
+				key,
+				status.http.headers?.[key]?.label,
+			),
+			validate: (input: string) =>
+				input.trim().length > 0 || "Please enter a value",
+		})),
+		...status.missing.query.map((key) => ({
+			type: "input",
+			name: `query:${key}`,
+			message: formatMissingInputMessage(
+				"query param",
+				key,
+				status.http.query?.[key]?.label,
+			),
+			validate: (input: string) =>
+				input.trim().length > 0 || "Please enter a value",
+		})),
+	]
+
+	if (prompts.length === 0) {
+		return {}
+	}
+
+	const answers = await inquirer.prompt(prompts)
+	const headers = Object.fromEntries(
+		status.missing.headers
+			.map((key) => [key, answers[`header:${key}`]])
+			.filter(([, value]) => typeof value === "string"),
+	)
+	const query = Object.fromEntries(
+		status.missing.query
+			.map((key) => [key, answers[`query:${key}`]])
+			.filter(([, value]) => typeof value === "string"),
+	)
+
+	return {
+		headers: Object.keys(headers).length > 0 ? headers : undefined,
+		query: Object.keys(query).length > 0 ? query : undefined,
+	}
+}
+
+function formatMissingInputMessage(
+	kind: string,
+	key: string,
+	label: string | undefined,
+): string {
+	return label ? `Enter ${label} (${kind}: ${key})` : `Enter ${kind}: ${key}`
 }


### PR DESCRIPTION
### What's added in this PR?

This PR adds the actual `input_required` CLI behavior on top of the lower stack branches: it preserves the raw structured status payload in JSON output, renders missing headers/query params in human `mcp add` and `mcp get` output, continues interactive `mcp add` flows in-place until the connection reaches a stable state, and surfaces unresolved-input issues in tool search/list output. It also keeps duplicate URL adds strict by showing remove/re-add guidance for unresolved connections and includes focused regression coverage for formatting, add flow, duplicate handling, list output, and tool status rendering.

#### Screenshots

N/A

### What's the issues or discussion related to this PR ?

The Connect API now persists `input_required`, but the CLI downgraded that response to `unknown`, which made missing-input connections unusable and hid the structured contract that agents and humans need to complete setup. This PR now sits on top of #717 and #718 so the feature diff is limited to the unresolved-input flow itself.
