### PR TITLE
chore: update @smithery/api to 0.58.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@biomejs/biome": "2.3.10",
 		"@modelcontextprotocol/sdk": "^1.25.3",
 		"@ngrok/ngrok": "^1.5.1",
-		"@smithery/api": "0.56.0",
+		"@smithery/api": "0.58.0",
 		"@smithery/sdk": "^4.1.0",
 		"@types/inquirer": "^8.2.4",
 		"@types/inquirer-autocomplete-prompt": "^3.0.3",
@@ -91,6 +91,5 @@
 	},
 	"engines": {
 		"node": ">=20.0.0"
-	},
-	"dependencies": {}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.5.1
         version: 1.7.0
       '@smithery/api':
-        specifier: 0.56.0
-        version: 0.56.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
+        specifier: 0.58.0
+        version: 0.58.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
       '@smithery/sdk':
         specifier: ^4.1.0
         version: 4.1.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))(zod@4.2.1)
@@ -884,8 +884,8 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
-  '@smithery/api@0.56.0':
-    resolution: {integrity: sha512-Ndi/4SZBULLQ7AifhR1bt4w8XUw7WeeW/u5SjtGzX1nKWYscRbNN7/OYuf/vMfzZHOWYWptNFe+a8Tr+Qp9XSQ==}
+  '@smithery/api@0.58.0':
+    resolution: {integrity: sha512-YgHU2qgrd6o2fQhNOuOthgmY5N6RPX/Gh+KENBUQDurUHup+vRp1t/wxcrqhacQauxEUJfuy5289RSR9m6M0dA==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
     peerDependenciesMeta:
@@ -2788,7 +2788,7 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@smithery/api@0.56.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
+  '@smithery/api@0.58.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.1)(zod@4.2.1)
 

--- a/src/commands/__tests__/deploy.test.ts
+++ b/src/commands/__tests__/deploy.test.ts
@@ -552,7 +552,12 @@ describe("deploy command", () => {
 
 	test("--from-build with stdio: uploads bundle artifact", async () => {
 		vi.mocked(loadBuildManifest).mockReturnValue({
-			payload: { type: "stdio", runtime: "node", hasAuthAdapter: false },
+			payload: {
+				type: "stdio",
+				runtime: "node",
+				stateful: false,
+				hasAuthAdapter: false,
+			},
 			bundlePath: "/my/prebuilt/server.mcpb",
 		})
 

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -13,7 +13,6 @@ import {
 	getNamespace as getStoredNamespace,
 	setNamespace,
 } from "../../utils/smithery-settings"
-
 export type { Connection, ConnectionsListResponse }
 
 export interface ToolInfo extends Tool {
@@ -68,7 +67,10 @@ export class ConnectSession {
 				cursor: options.cursor,
 				...metadataQuery,
 			} as ListConnectionsParams)
-			return { connections: data.connections, nextCursor: data.nextCursor }
+			return {
+				connections: data.connections,
+				nextCursor: data.nextCursor,
+			}
 		}
 
 		// Fetch pages until we have enough results (or all if no limit)
@@ -206,7 +208,7 @@ export class ConnectSession {
 			}),
 		} as Parameters<typeof this.smitheryClient.connections.set>[1]
 		try {
-			return await this.smitheryClient.connections.set(connectionId, params)
+			return this.smitheryClient.connections.set(connectionId, params)
 		} catch (error) {
 			if (error instanceof Error && error.message.includes("409")) {
 				await this.deleteConnection(connectionId)

--- a/src/commands/mcp/deploy.ts
+++ b/src/commands/mcp/deploy.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { NotFoundError, type Smithery } from "@smithery/api"
 import type {
-	DeployPayload,
 	ReleaseDeployParams,
 	ReleaseGetResponse,
 } from "@smithery/api/resources/servers/releases"
@@ -12,6 +11,7 @@ import pc from "picocolors"
 import { buildBundle, loadBuildManifest } from "../../lib/bundle/index.js"
 import { fatal } from "../../lib/cli-error"
 import { loadProjectConfig } from "../../lib/config-loader.js"
+import type { DeployPayload } from "../../lib/deploy-payload.js"
 import { resolveNamespace } from "../../lib/namespace.js"
 import { createSmitheryClientSync } from "../../lib/smithery-client"
 import { parseConfigSchema } from "../../utils/cli-utils.js"

--- a/src/lib/bundle/index.ts
+++ b/src/lib/bundle/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
-import type { DeployPayload } from "@smithery/api/resources/servers/releases"
 import { loadProjectConfig } from "../config-loader.js"
+import type { DeployPayload } from "../deploy-payload.js"
 import { buildShttpBundle } from "./shttp.js"
 import { buildStdioBundle } from "./stdio.js"
 

--- a/src/lib/bundle/shttp.ts
+++ b/src/lib/bundle/shttp.ts
@@ -1,10 +1,10 @@
 import { execSync } from "node:child_process"
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import type { DeployPayload } from "@smithery/api/resources/servers/releases"
 import pc from "picocolors"
 
 import { buildServer } from "../build.js"
+import type { DeployPayload } from "../deploy-payload.js"
 import type { BuildManifest } from "./index.js"
 import { type ScanResult, scanModule } from "./scan.js"
 

--- a/src/lib/bundle/stdio.ts
+++ b/src/lib/bundle/stdio.ts
@@ -8,11 +8,11 @@ import {
 } from "node:fs"
 import { join } from "node:path"
 import { packExtension } from "@anthropic-ai/mcpb"
-import type { DeployPayload } from "@smithery/api/resources/servers/releases"
 import pc from "picocolors"
 
 import { buildServer } from "../build.js"
 import { loadProjectConfig } from "../config-loader.js"
+import type { DeployPayload } from "../deploy-payload.js"
 import { copyBundleAssets } from "./copy-assets.js"
 import type { BuildManifest } from "./index.js"
 import { createMcpbManifest, MCPB_ENTRY_POINT } from "./mcpb-manifest.js"
@@ -105,6 +105,7 @@ export async function buildStdioBundle(
 	const payload: DeployPayload = {
 		type: "stdio" as const,
 		runtime: "node" as const,
+		stateful: false,
 		hasAuthAdapter: scanResult.hasAuthAdapter ?? false,
 		configSchema: scanResult.configSchema,
 		serverCard: scanResult.serverCard,

--- a/src/lib/deploy-payload.ts
+++ b/src/lib/deploy-payload.ts
@@ -1,0 +1,11 @@
+import type {
+	DeployPayload as ApiDeployPayload,
+	HostedDeployPayload,
+} from "@smithery/api/resources/servers/releases"
+
+export type StdioDeployPayload = Omit<HostedDeployPayload, "type"> & {
+	type: "stdio"
+	runtime: "node"
+}
+
+export type DeployPayload = ApiDeployPayload | StdioDeployPayload

--- a/src/utils/install/__tests__/fixtures/servers.ts
+++ b/src/utils/install/__tests__/fixtures/servers.ts
@@ -11,7 +11,6 @@ export const noConfigServer: Server = {
 	deploymentUrl: null,
 	security: null,
 	tools: null,
-	eventTopics: null,
 	prompts: null,
 	resources: null,
 	connections: [
@@ -31,7 +30,6 @@ export const requiredOnlyServer: Server = {
 	deploymentUrl: "https://server.smithery.ai",
 	security: null,
 	tools: null,
-	eventTopics: null,
 	prompts: null,
 	resources: null,
 	connections: [
@@ -63,7 +61,6 @@ export const requiredAndOptionalServer: Server = {
 	deploymentUrl: null,
 	security: null,
 	tools: null,
-	eventTopics: null,
 	prompts: null,
 	resources: null,
 	connections: [


### PR DESCRIPTION
### What's added in this PR?

This PR upgrades the CLI to `@smithery/api` 0.58.0 so the branch can use the published `input_required` connection model from the official SDK. It also removes the local connection-type widening in the CLI, updates fixtures/tests for the generator's new server types, and adds a small local deploy-payload compat alias because the published SDK still omits the stdio release payload from its `DeployPayload` union.

#### Screenshots

N/A

### What's the issues or discussion related to this PR ?

This is the bottom of the stack for the `input_required` CLI work. The upstream API and SDK support landed in smithery-ai/mono#1975 and smithery-ai/typescript-api#86, so this PR moves the CLI onto that official contract before the feature PR layers on top.
