### PR TITLE
fix: use setupUrl in connect flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@biomejs/biome": "2.3.10",
 		"@modelcontextprotocol/sdk": "^1.25.3",
 		"@ngrok/ngrok": "^1.5.1",
-		"@smithery/api": "0.58.0",
+		"@smithery/api": "0.59.0",
 		"@smithery/sdk": "^4.1.0",
 		"@types/inquirer": "^8.2.4",
 		"@types/inquirer-autocomplete-prompt": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.5.1
         version: 1.7.0
       '@smithery/api':
-        specifier: 0.58.0
-        version: 0.58.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
+        specifier: 0.59.0
+        version: 0.59.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
       '@smithery/sdk':
         specifier: ^4.1.0
         version: 4.1.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))(zod@4.2.1)
@@ -884,8 +884,8 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
-  '@smithery/api@0.58.0':
-    resolution: {integrity: sha512-YgHU2qgrd6o2fQhNOuOthgmY5N6RPX/Gh+KENBUQDurUHup+vRp1t/wxcrqhacQauxEUJfuy5289RSR9m6M0dA==}
+  '@smithery/api@0.59.0':
+    resolution: {integrity: sha512-CpXGjNHZ4x0SrLIkBCj9WG/FKgv/Qx72EDLXAIz7Jl1oUdpwD5we8kB3+41LSDhM/6vDJxBUPYbx0qA3dPQGJw==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
     peerDependenciesMeta:
@@ -2788,7 +2788,7 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@smithery/api@0.58.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
+  '@smithery/api@0.59.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.1)(zod@4.2.1)
 

--- a/src/commands/__tests__/format-connection.test.ts
+++ b/src/commands/__tests__/format-connection.test.ts
@@ -38,6 +38,25 @@ describe("formatConnectionOutput", () => {
 		expect(output.status).toEqual(status)
 	})
 
+	test("prefers setupUrl for auth_required status output", () => {
+		const output = formatConnectionOutput({
+			connectionId: "github-oauth",
+			name: "github-oauth",
+			mcpUrl: "https://server.smithery.ai/github",
+			metadata: null,
+			status: {
+				state: "auth_required",
+				setupUrl: "https://smithery.ai/setup/github",
+				authorizationUrl: "https://example.com/oauth",
+			},
+		} as never)
+
+		expect(output.status).toEqual({
+			state: "auth_required",
+			setupUrl: "https://smithery.ai/setup/github",
+		})
+	})
+
 	test("does not expose iconUrl in CLI output", () => {
 		const output = formatConnectionOutput({
 			connectionId: "browserbase",

--- a/src/commands/__tests__/format-connection.test.ts
+++ b/src/commands/__tests__/format-connection.test.ts
@@ -47,7 +47,6 @@ describe("formatConnectionOutput", () => {
 			status: {
 				state: "auth_required",
 				setupUrl: "https://smithery.ai/setup/github",
-				authorizationUrl: "https://example.com/oauth",
 			},
 		} as never)
 

--- a/src/commands/__tests__/mcp-add-impl.test.ts
+++ b/src/commands/__tests__/mcp-add-impl.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
 	mockListConnectionsByUrl,
@@ -34,8 +34,15 @@ vi.mock("../mcp/output-connection", () => ({
 import { addServer } from "../mcp/add-impl"
 
 describe("mcp add duplicate handling", () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
 	beforeEach(() => {
 		vi.clearAllMocks()
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore()
 	})
 
 	test("shows a remove and re-add hint for unresolved duplicate connections", async () => {
@@ -83,6 +90,37 @@ describe("mcp add duplicate handling", () => {
 				tip: expect.stringContaining(
 					"smithery mcp remove test-input-required-two",
 				),
+			}),
+		)
+	})
+
+	test("prints setupUrl for auth_required duplicate connections", async () => {
+		mockListConnectionsByUrl.mockResolvedValue({
+			connections: [
+				{
+					connectionId: "github-oauth",
+					name: "github-oauth",
+					mcpUrl: "https://server.smithery.ai/github",
+					metadata: null,
+					status: {
+						state: "auth_required",
+						setupUrl: "https://smithery.ai/setup/github",
+					},
+				},
+			],
+		})
+
+		await addServer("https://server.smithery.ai/github", {})
+
+		expect(mockCreateConnection).not.toHaveBeenCalled()
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'Authorization required. Run: open "https://smithery.ai/setup/github"',
+			),
+		)
+		expect(mockOutputConnectionDetail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tip: "Use the setup URL above to complete setup.",
 			}),
 		)
 	})

--- a/src/commands/__tests__/tools-find.test.ts
+++ b/src/commands/__tests__/tools-find.test.ts
@@ -429,4 +429,42 @@ describe("tools find command", () => {
 			}),
 		)
 	})
+
+	test("reports auth_required setupUrl in connection issues", async () => {
+		mockGetConnection.mockResolvedValue({
+			connectionId: "github-oauth",
+			name: "github-oauth",
+			mcpUrl: "https://server.smithery.ai/github",
+			status: {
+				state: "auth_required",
+				setupUrl: "https://smithery.ai/setup/github",
+				authorizationUrl: "https://example.com/oauth",
+			},
+		})
+		mockListToolsForConnection.mockRejectedValue(
+			new Error("connection requires authorization"),
+		)
+
+		await findTools(undefined, {
+			connection: "github-oauth",
+			prefix: undefined,
+		})
+
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					tools: [],
+					connectionIssues: [
+						expect.objectContaining({
+							error: 'Server "github-oauth" requires authentication',
+							status: {
+								state: "auth_required",
+								setupUrl: "https://smithery.ai/setup/github",
+							},
+						}),
+					],
+				}),
+			}),
+		)
+	})
 })

--- a/src/commands/__tests__/tools-find.test.ts
+++ b/src/commands/__tests__/tools-find.test.ts
@@ -438,7 +438,6 @@ describe("tools find command", () => {
 			status: {
 				state: "auth_required",
 				setupUrl: "https://smithery.ai/setup/github",
-				authorizationUrl: "https://example.com/oauth",
 			},
 		})
 		mockListToolsForConnection.mockRejectedValue(

--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -5,6 +5,7 @@ import {
 	finalizeAddedConnection,
 } from "./add-flow"
 import { ConnectSession } from "./api"
+import { getConnectionSetupUrl } from "./connection-status"
 import { normalizeMcpUrl } from "./normalize-url"
 import { outputConnectionDetail } from "./output-connection"
 import { parseJsonObject } from "./parse-json"
@@ -44,11 +45,10 @@ export async function addServer(
 					),
 				)
 				if (status === "auth_required") {
-					const authUrl = (match.status as { authorizationUrl?: string })
-						?.authorizationUrl
-					if (authUrl) {
+					const setupUrl = getConnectionSetupUrl(match.status)
+					if (setupUrl) {
 						console.error(
-							pc.yellow(`Authorization required. Run: open "${authUrl}"`),
+							pc.yellow(`Authorization required. Run: open "${setupUrl}"`),
 						)
 					}
 				} else if (status === "connected") {
@@ -63,7 +63,7 @@ export async function addServer(
 					(status === "connected"
 						? `Use smithery tool list ${match.connectionId} to interact with it.`
 						: status === "auth_required"
-							? "Use the authorization URL above to complete setup."
+							? "Use the setup URL above to complete setup."
 							: `Use --force to create a new connection anyway.`)
 				outputConnectionDetail({
 					connection: match,
@@ -88,11 +88,10 @@ export async function addServer(
 		})
 
 		if (finalConnection.status?.state === "auth_required") {
-			const authUrl = (finalConnection.status as { authorizationUrl?: string })
-				?.authorizationUrl
-			if (authUrl) {
+			const setupUrl = getConnectionSetupUrl(finalConnection.status)
+			if (setupUrl) {
 				console.error(
-					pc.yellow(`Authorization required. Run: open "${authUrl}"`),
+					pc.yellow(`Authorization required. Run: open "${setupUrl}"`),
 				)
 			}
 		}

--- a/src/commands/mcp/connection-status.ts
+++ b/src/commands/mcp/connection-status.ts
@@ -13,6 +13,19 @@ export function isInputRequiredStatus(
 	return status?.state === "input_required"
 }
 
+export function getConnectionSetupUrl(
+	status:
+		| {
+				state?: string
+				setupUrl?: string
+				authorizationUrl?: string
+		  }
+		| null
+		| undefined,
+): string | undefined {
+	return status?.setupUrl ?? status?.authorizationUrl
+}
+
 export function rewriteConnectionUrl(
 	mcpUrl: string,
 	query: Record<string, string> | undefined,

--- a/src/commands/mcp/connection-status.ts
+++ b/src/commands/mcp/connection-status.ts
@@ -18,12 +18,11 @@ export function getConnectionSetupUrl(
 		| {
 				state?: string
 				setupUrl?: string
-				authorizationUrl?: string
 		  }
 		| null
 		| undefined,
 ): string | undefined {
-	return status?.setupUrl ?? status?.authorizationUrl
+	return status?.setupUrl
 }
 
 export function rewriteConnectionUrl(

--- a/src/commands/mcp/format-connection.ts
+++ b/src/commands/mcp/format-connection.ts
@@ -1,5 +1,8 @@
 import type { Connection } from "./api"
-import { isInputRequiredStatus } from "./connection-status"
+import {
+	getConnectionSetupUrl,
+	isInputRequiredStatus,
+} from "./connection-status"
 
 /**
  * Format a Connection object for output, including all relevant fields.
@@ -43,8 +46,9 @@ function formatStatus(
 
 	if (status.state === "auth_required") {
 		const result: Record<string, unknown> = { state: "auth_required" }
-		if (status.authorizationUrl) {
-			result.authorizationUrl = status.authorizationUrl
+		const setupUrl = getConnectionSetupUrl(status)
+		if (setupUrl) {
+			result.setupUrl = setupUrl
 		}
 		return result
 	}

--- a/src/commands/mcp/search.ts
+++ b/src/commands/mcp/search.ts
@@ -2,7 +2,10 @@ import FlexSearch from "flexsearch"
 import pc from "picocolors"
 import { isJsonMode, outputJson, outputTable } from "../../utils/output"
 import { type Connection, ConnectSession, type ToolInfo } from "./api"
-import { isInputRequiredStatus } from "./connection-status"
+import {
+	getConnectionSetupUrl,
+	isInputRequiredStatus,
+} from "./connection-status"
 import {
 	formatGroupRow,
 	formatListToolRow,
@@ -24,11 +27,9 @@ function formatConnectionStatus(
 
 	if (connection.status.state === "auth_required") {
 		const status: Record<string, unknown> = { state: "auth_required" }
-		if (
-			"authorizationUrl" in connection.status &&
-			connection.status.authorizationUrl
-		) {
-			status.authorizationUrl = connection.status.authorizationUrl
+		const setupUrl = getConnectionSetupUrl(connection.status)
+		if (setupUrl) {
+			status.setupUrl = setupUrl
 		}
 		return {
 			error: `Server "${connection.name}" requires authentication`,
@@ -252,10 +253,10 @@ export async function findTools(
 
 	if (!isJson && issues.length > 0) {
 		for (const issue of issues) {
-			const authUrl = issue.status?.authorizationUrl as string | undefined
+			const setupUrl = issue.status?.setupUrl as string | undefined
 			console.error(pc.yellow(issue.error))
-			if (authUrl) {
-				console.error(pc.yellow(`Authorize at: ${authUrl}`))
+			if (setupUrl) {
+				console.error(pc.yellow(`Complete setup at: ${setupUrl}`))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- bump @smithery/api to 0.59.0
- prefer setupUrl over the deprecated authorizationUrl in connection output and add/search flows
- add focused tests covering auth-required output, tool search issues, and duplicate add messaging

## Testing
- pnpm check
- pnpm typecheck
- pnpm test