### PR TITLE
fix: make CLI auth organization aware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ interface CliOptions {
 	client?: string
 	full?: boolean
 	namespace?: string
+	organization?: string
 	metadata?: string
 	agent?: string
 	global?: boolean
@@ -357,20 +358,46 @@ async function handleSecretsDelete(server: string, name: string) {
 	await deleteSecret(server, name)
 }
 
-async function handleLogin() {
+async function handleLogin(options: CliOptions = {}) {
 	const { executeCliAuthFlow } = await import("./lib/cli-auth")
 	const { validateApiKey } = await import("./lib/registry")
+	const { setAuthOrganization, setNamespace } = await import(
+		"./utils/smithery-settings"
+	)
 
 	console.log(pc.cyan("Login to Smithery"))
 	console.log()
 
 	try {
-		const apiKey = await executeCliAuthFlow()
+		const authResult = await executeCliAuthFlow({
+			organization:
+				typeof options.organization === "string"
+					? options.organization
+					: undefined,
+		})
+		const { apiKey } = authResult
 		await validateApiKey(apiKey)
 		const result = await setApiKey(apiKey)
+		if (authResult.namespace) {
+			await setNamespace(authResult.namespace)
+		}
+		if (authResult.organization) {
+			await setAuthOrganization({
+				id: authResult.organization.id,
+				name: authResult.organization.name,
+			})
+		}
 
 		if (result.success) {
 			console.log(pc.green("✓ Successfully logged in"))
+			if (authResult.organization) {
+				const organizationLabel =
+					authResult.organization.name || authResult.organization.id
+				console.log(pc.gray(`Organization: ${organizationLabel}`))
+			}
+			if (authResult.namespace) {
+				console.log(pc.gray(`Namespace: ${authResult.namespace}`))
+			}
 			console.log(pc.gray("You can now use Smithery CLI commands"))
 		} else {
 			console.error(pc.red("✗ Failed to save API key"))
@@ -384,7 +411,7 @@ async function handleLogin() {
 }
 
 async function handleLogout() {
-	const { clearApiKey, clearNamespace } = await import(
+	const { clearApiKey, clearAuthOrganization, clearNamespace } = await import(
 		"./utils/smithery-settings"
 	)
 	const { clearAllConfigs } = await import("./lib/keychain.js")
@@ -392,6 +419,7 @@ async function handleLogout() {
 	console.log(pc.cyan("Logging out of Smithery..."))
 	await clearApiKey()
 	await clearNamespace()
+	await clearAuthOrganization()
 	await clearAllConfigs()
 	console.log(pc.green("✓ Successfully logged out"))
 	console.log(pc.gray("All local credentials have been removed"))
@@ -410,8 +438,22 @@ async function handleWhoami(options: CliOptions) {
 		if (options.full) {
 			console.log(`SMITHERY_API_KEY=${apiKey}`)
 		} else {
+			const { getAuthOrganization, getNamespace } = await import(
+				"./utils/smithery-settings"
+			)
 			const masked = `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`
 			console.log(pc.cyan("Token:"), masked)
+			const organization = await getAuthOrganization()
+			if (organization) {
+				const organizationLabel = organization.name
+					? `${organization.name} (${organization.id})`
+					: organization.id
+				console.log(pc.cyan("Organization:"), organizationLabel)
+			}
+			const namespace = await getNamespace()
+			if (namespace) {
+				console.log(pc.cyan("Namespace:"), namespace)
+			}
 			console.log(pc.gray("Use --full to display the complete token"))
 		}
 	} catch (_error) {
@@ -1030,6 +1072,10 @@ auth
 	.description(
 		"Login with Smithery (non-TTY: outputs JSON with auth_url for agents)",
 	)
+	.option(
+		"--organization <organization-id>",
+		"WorkOS organization ID to use for organization-scoped login",
+	)
 	.action(handleLogin)
 
 auth
@@ -1194,7 +1240,13 @@ registerAlias(program, "search [term]", searchCmd, handleSearch)
 registerAlias(program, "dev [entryFile]", devCmd, handleDev)
 registerAlias(program, "build [entryFile]", buildCmd, handleBuild)
 registerAlias(program, "publish [server]", publishCmd, handlePublish)
-program.command("login", { hidden: true }).action(handleLogin)
+program
+	.command("login", { hidden: true })
+	.option(
+		"--organization <organization-id>",
+		"WorkOS organization ID to use for organization-scoped login",
+	)
+	.action(handleLogin)
 program.command("logout", { hidden: true }).action(handleLogout)
 registerAlias(program, "whoami", whoamiCmd, handleWhoami)
 

--- a/src/lib/__tests__/cli-auth.test.ts
+++ b/src/lib/__tests__/cli-auth.test.ts
@@ -1,0 +1,156 @@
+import { exec } from "node:child_process"
+import inquirer from "inquirer"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import yoctoSpinner from "yocto-spinner"
+
+vi.mock("node:child_process", () => ({
+	exec: vi.fn((_command, callback) => callback(null, "", "")),
+}))
+
+vi.mock("inquirer", () => ({
+	default: {
+		prompt: vi.fn(),
+	},
+}))
+
+vi.mock("yocto-spinner", () => ({
+	default: vi.fn(() => ({
+		start: vi.fn().mockReturnThis(),
+		success: vi.fn().mockReturnThis(),
+		error: vi.fn().mockReturnThis(),
+		stop: vi.fn().mockReturnThis(),
+	})),
+}))
+
+const originalIsTTY = process.stdin.isTTY
+
+function setIsTTY(value: boolean) {
+	Object.defineProperty(process.stdin, "isTTY", {
+		configurable: true,
+		value,
+	})
+}
+
+function mockFetchResponses(responses: unknown[]) {
+	const fetchMock = vi.fn()
+	for (const response of responses) {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: vi.fn().mockResolvedValue(response),
+			text: vi.fn().mockResolvedValue(JSON.stringify(response)),
+		})
+	}
+	vi.stubGlobal("fetch", fetchMock)
+	return fetchMock
+}
+
+describe("executeCliAuthFlow", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, "log").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			configurable: true,
+			value: originalIsTTY,
+		})
+		vi.unstubAllGlobals()
+		vi.restoreAllMocks()
+	})
+
+	test("passes organization option when creating auth session", async () => {
+		setIsTTY(false)
+		const fetchMock = mockFetchResponses([
+			{
+				sessionId: "session-1",
+				authUrl: "https://smithery.ai/auth/cli?s=session-1",
+			},
+			{
+				status: "success",
+				apiKey: "smy_test",
+				organization: { id: "org_123", name: "Acme" },
+				namespace: "acme",
+			},
+		])
+
+		const { executeCliAuthFlow } = await import("../cli-auth")
+		const result = await executeCliAuthFlow({
+			organization: "org_123",
+			pollInterval: 1,
+			timeoutMs: 50,
+		})
+
+		expect(result).toEqual({
+			apiKey: "smy_test",
+			organization: { id: "org_123", name: "Acme" },
+			namespace: "acme",
+		})
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"https://smithery.ai/api/auth/cli/session",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ organizationId: "org_123" }),
+			},
+		)
+		expect(console.log).toHaveBeenCalledWith(
+			JSON.stringify({
+				auth_url:
+					"https://smithery.ai/auth/cli?s=session-1&organization_id=org_123",
+				session_id: "session-1",
+			}),
+		)
+	})
+
+	test("prompts and submits organization selection when poll requires it", async () => {
+		setIsTTY(true)
+		vi.mocked(inquirer.prompt).mockResolvedValue({ organizationId: "org_456" })
+		const fetchMock = mockFetchResponses([
+			{
+				sessionId: "session-2",
+				authUrl: "https://smithery.ai/auth/cli?s=session-2",
+			},
+			{
+				status: "organization_selection_required",
+				organizations: [
+					{ id: "org_123", name: "Personal" },
+					{ id: "org_456", name: "Team" },
+				],
+			},
+			{
+				status: "success",
+				apiKey: "smy_team",
+				organization: { id: "org_456", name: "Team", namespace: "team" },
+			},
+		])
+
+		const { executeCliAuthFlow } = await import("../cli-auth")
+		const result = await executeCliAuthFlow({ pollInterval: 1, timeoutMs: 50 })
+
+		expect(result).toEqual({
+			apiKey: "smy_team",
+			organization: { id: "org_456", name: "Team", namespace: "team" },
+			namespace: "team",
+		})
+		expect(inquirer.prompt).toHaveBeenCalledWith([
+			expect.objectContaining({
+				type: "list",
+				name: "organizationId",
+				message: "Select organization:",
+			}),
+		])
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			3,
+			"https://smithery.ai/api/auth/cli/session/session-2/organization",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ organizationId: "org_456" }),
+			},
+		)
+		expect(yoctoSpinner).toHaveBeenCalled()
+		expect(exec).toHaveBeenCalled()
+	})
+})

--- a/src/lib/cli-auth.ts
+++ b/src/lib/cli-auth.ts
@@ -18,13 +18,29 @@ interface CliAuthSession {
 	authUrl: string
 }
 
+interface CliAuthOrganization {
+	id: string
+	name?: string
+	slug?: string
+	namespace?: string
+}
+
+export interface CliAuthResult {
+	apiKey: string
+	organization?: CliAuthOrganization
+	namespace?: string
+}
+
 /**
  * Response from polling for auth completion
  */
 interface PollResponse {
-	status: "pending" | "success" | "error"
+	status: "pending" | "success" | "error" | "organization_selection_required"
 	apiKey?: string
 	message?: string
+	organization?: CliAuthOrganization
+	namespace?: string
+	organizations?: CliAuthOrganization[]
 }
 
 /**
@@ -33,6 +49,11 @@ interface PollResponse {
 export interface CliAuthOptions {
 	pollInterval?: number
 	timeoutMs?: number
+	/**
+	 * WorkOS organization ID to preselect during login when supported by the
+	 * Smithery auth service.
+	 */
+	organization?: string
 }
 
 /**
@@ -57,6 +78,23 @@ function isNetworkError(error: unknown): boolean {
 	return false
 }
 
+function withOrganizationInAuthUrl(
+	authUrl: string,
+	organizationId: string | undefined,
+): string {
+	if (!organizationId) return authUrl
+
+	try {
+		const url = new URL(authUrl)
+		if (!url.searchParams.has("organization_id")) {
+			url.searchParams.set("organization_id", organizationId)
+		}
+		return url.toString()
+	} catch {
+		return authUrl
+	}
+}
+
 /**
  * Create a new CLI authentication session
  * @param registryEndpoint Base URL for the registry
@@ -64,13 +102,21 @@ function isNetworkError(error: unknown): boolean {
  */
 async function createAuthSession(
 	registryEndpoint: string,
+	options: CliAuthOptions,
 ): Promise<CliAuthSession> {
 	const sessionUrl = `${registryEndpoint}/api/auth/cli/session`
 	verbose(`Creating auth session at ${sessionUrl}`)
+	const body = options.organization
+		? JSON.stringify({ organizationId: options.organization })
+		: undefined
 
 	try {
 		const response = await fetch(sessionUrl, {
 			method: "POST",
+			...(body && {
+				headers: { "Content-Type": "application/json" },
+				body,
+			}),
 		})
 
 		if (!response.ok) {
@@ -89,6 +135,7 @@ async function createAuthSession(
 		}
 
 		const data = (await response.json()) as CliAuthSession
+		data.authUrl = withOrganizationInAuthUrl(data.authUrl, options.organization)
 		verbose(`Session created: ${data.sessionId}`)
 		return data
 	} catch (error) {
@@ -99,6 +146,71 @@ async function createAuthSession(
 		}
 		throw error
 	}
+}
+
+function formatOrganizationChoice(organization: CliAuthOrganization): string {
+	const label = organization.name || organization.slug || organization.id
+	return label === organization.id ? label : `${label} (${organization.id})`
+}
+
+async function promptForOrganizationSelection(
+	organizations: CliAuthOrganization[],
+): Promise<string> {
+	if (!process.stdin.isTTY) {
+		console.log(
+			JSON.stringify({
+				status: "organization_selection_required",
+				organizations,
+			}),
+		)
+		throw new Error(
+			"Authentication requires organization selection. Re-run in an interactive terminal or pass --organization <organization-id>.",
+		)
+	}
+
+	const inquirer = (await import("inquirer")).default
+	const { organizationId } = await inquirer.prompt([
+		{
+			type: "list",
+			name: "organizationId",
+			message: "Select organization:",
+			choices: organizations.map((organization) => ({
+				name: formatOrganizationChoice(organization),
+				value: organization.id,
+			})),
+		},
+	])
+
+	return organizationId
+}
+
+async function submitOrganizationSelection(
+	sessionId: string,
+	registryEndpoint: string,
+	organizationId: string,
+): Promise<PollResponse> {
+	const selectUrl = `${registryEndpoint}/api/auth/cli/session/${sessionId}/organization`
+	verbose(`Submitting auth organization selection at ${selectUrl}`)
+
+	const response = await fetch(selectUrl, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ organizationId }),
+	})
+
+	if (!response.ok) {
+		const errorText = await response.text().catch(() => "")
+		verbose(
+			`Organization selection failed: ${response.status} ${errorText || response.statusText}`,
+		)
+		throw new Error(
+			response.status === 404
+				? "Authentication service does not support CLI organization selection yet."
+				: `Failed to select organization: ${response.statusText}`,
+		)
+	}
+
+	return (await response.json()) as PollResponse
 }
 
 /**
@@ -187,7 +299,10 @@ async function pollForApiKey(
 	sessionId: string,
 	registryEndpoint: string,
 	options: CliAuthOptions,
-): Promise<string> {
+	onOrganizationSelectionRequired?: (
+		organizations: CliAuthOrganization[],
+	) => Promise<string>,
+): Promise<CliAuthResult> {
 	const pollInterval = options.pollInterval || DEFAULT_POLL_INTERVAL
 	const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT
 	const maxPolls = Math.floor(timeoutMs / pollInterval)
@@ -202,17 +317,51 @@ async function pollForApiKey(
 		attempts++
 
 		try {
-			const data = await pollWithRetry(pollUrl, 1)
+			let data = await pollWithRetry(pollUrl, 1)
 
 			if (data.status === "success" && data.apiKey) {
 				verbose("Authentication successful")
-				return data.apiKey
+				return {
+					apiKey: data.apiKey,
+					organization: data.organization,
+					namespace: data.namespace || data.organization?.namespace,
+				}
 			}
 
 			if (data.status === "error") {
 				const errorMessage = data.message || "Authentication failed"
 				verbose(`Authentication error: ${errorMessage}`)
 				throw new Error(errorMessage)
+			}
+
+			if (data.status === "organization_selection_required") {
+				const organizations = data.organizations || []
+				if (organizations.length === 0) {
+					throw new Error(
+						data.message ||
+							"Authentication requires organization selection, but no organizations were returned.",
+					)
+				}
+				const organizationId = onOrganizationSelectionRequired
+					? await onOrganizationSelectionRequired(organizations)
+					: await promptForOrganizationSelection(organizations)
+				data = await submitOrganizationSelection(
+					sessionId,
+					registryEndpoint,
+					organizationId,
+				)
+				if (data.status === "success" && data.apiKey) {
+					verbose("Authentication successful after organization selection")
+					return {
+						apiKey: data.apiKey,
+						organization:
+							data.organization ||
+							organizations.find(
+								(organization) => organization.id === organizationId,
+							),
+						namespace: data.namespace || data.organization?.namespace,
+					}
+				}
 			}
 
 			// status === "pending", keep polling
@@ -255,11 +404,11 @@ const SMITHERY_URL = process.env.SMITHERY_URL || "https://smithery.ai"
 /**
  * Execute the complete CLI authentication flow
  * @param options Authentication options
- * @returns API key on success
+ * @returns API key and auth context on success
  */
 export async function executeCliAuthFlow(
 	options: CliAuthOptions = {},
-): Promise<string> {
+): Promise<CliAuthResult> {
 	verbose(`Starting CLI auth flow with endpoint: ${SMITHERY_URL}`)
 	const isTTY = process.stdin.isTTY
 
@@ -273,7 +422,7 @@ export async function executeCliAuthFlow(
 
 	let session: CliAuthSession
 	try {
-		session = await createAuthSession(SMITHERY_URL)
+		session = await createAuthSession(SMITHERY_URL, options)
 		sessionSpinner?.success("Authentication ready")
 	} catch (error) {
 		sessionSpinner?.error("Failed to start authentication")
@@ -307,7 +456,7 @@ export async function executeCliAuthFlow(
 	}
 
 	// Step 3: Poll for completion
-	const pollSpinner = isTTY
+	let pollSpinner = isTTY
 		? yoctoSpinner({
 				text: "Waiting for you to authorize in browser...",
 				color: "yellow",
@@ -315,9 +464,26 @@ export async function executeCliAuthFlow(
 		: null
 
 	try {
-		const apiKey = await pollForApiKey(session.sessionId, SMITHERY_URL, options)
+		const authResult = await pollForApiKey(
+			session.sessionId,
+			SMITHERY_URL,
+			options,
+			async (organizations) => {
+				pollSpinner?.stop()
+				console.log()
+				const organizationId =
+					await promptForOrganizationSelection(organizations)
+				pollSpinner = isTTY
+					? yoctoSpinner({
+							text: "Completing organization-scoped login...",
+							color: "yellow",
+						}).start()
+					: null
+				return organizationId
+			},
+		)
 		pollSpinner?.success("Authorization received")
-		return apiKey
+		return authResult
 	} catch (error) {
 		pollSpinner?.error("Authorization failed")
 		throw error

--- a/src/utils/smithery-settings.ts
+++ b/src/utils/smithery-settings.ts
@@ -11,6 +11,10 @@ interface Settings {
 	askedConsent: boolean
 	apiKey?: string
 	namespace?: string
+	authOrganization?: {
+		id: string
+		name?: string
+	}
 	cache?: {
 		servers?: Record<
 			string,
@@ -297,6 +301,19 @@ export const clearNamespace = async (): Promise<SettingsResult> => {
 	return await saveSettings(settingsData, getSettingsPath())
 }
 
+export const clearAuthOrganization = async (): Promise<SettingsResult> => {
+	const initResult = await initializeSettings()
+	if (!initResult.success || !initResult.data) {
+		return initResult
+	}
+
+	const { authOrganization: _removed, ...settingsWithoutOrganization } =
+		initResult.data
+	settingsData = settingsWithoutOrganization as Settings
+
+	return await saveSettings(settingsData, getSettingsPath())
+}
+
 export const hasAskedConsent = async (): Promise<boolean> => {
 	await initializeSettings()
 	return settingsData?.askedConsent || false
@@ -316,6 +333,26 @@ export const setNamespace = async (
 	}
 
 	settingsData = { ...initResult.data, namespace }
+
+	return await saveSettings(settingsData, getSettingsPath())
+}
+
+export const getAuthOrganization = async (): Promise<
+	Settings["authOrganization"] | undefined
+> => {
+	await initializeSettings()
+	return settingsData?.authOrganization
+}
+
+export const setAuthOrganization = async (
+	organization: NonNullable<Settings["authOrganization"]>,
+): Promise<SettingsResult> => {
+	const initResult = await initializeSettings()
+	if (!initResult.success || !initResult.data) {
+		return initResult
+	}
+
+	settingsData = { ...initResult.data, authOrganization: organization }
 
 	return await saveSettings(settingsData, getSettingsPath())
 }


### PR DESCRIPTION
## Summary
- add an organization-aware CLI login option and pass organization context into auth session creation/browser URLs
- handle organization-selection-required auth poll responses and persist returned organization/namespace metadata
- show stored organization and namespace in whoami and clear them on logout
- add focused tests for organization-aware CLI auth flows

## Verification
- pnpm vitest run src/lib/__tests__/cli-auth.test.ts
- pnpm exec biome check src/lib/cli-auth.ts src/index.ts src/utils/smithery-settings.ts src/lib/__tests__/cli-auth.test.ts

## Notes
- Full build/typecheck is currently blocked by existing repo-wide errors unrelated to this change, including missing fflate types and @smithery/api connection status type mismatches.