### PR TITLE
feat: support uplink in mcp add

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@anthropic-ai/mcpb": "^1.1.1",
 		"@biomejs/biome": "2.3.10",
 		"@modelcontextprotocol/sdk": "^1.25.3",
-		"@smithery/api": "https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz",
+		"@smithery/api": "https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz",
 		"@smithery/sdk": "^4.1.0",
 		"@types/inquirer": "^8.2.4",
 		"@types/inquirer-autocomplete-prompt": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@anthropic-ai/mcpb": "^1.1.1",
 		"@biomejs/biome": "2.3.10",
 		"@modelcontextprotocol/sdk": "^1.25.3",
-		"@smithery/api": "0.59.0",
+		"@smithery/api": "https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz",
 		"@smithery/sdk": "^4.1.0",
 		"@types/inquirer": "^8.2.4",
 		"@types/inquirer-autocomplete-prompt": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.25.3
         version: 1.25.3(hono@4.11.1)(zod@4.2.1)
       '@smithery/api':
-        specifier: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz
-        version: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
+        specifier: https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz
+        version: https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
       '@smithery/sdk':
         specifier: ^4.1.0
         version: 4.1.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))(zod@4.2.1)
@@ -800,8 +800,8 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
-  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz':
-    resolution: {integrity: sha512-8QELSglbj/tXG14rHc+Gjnn2QjplKbbgbn47NsG02QPcUHpzyDnGcKAXXejha0gmjlIcAj4M/Gtri0pTvlFkPA==, tarball: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz}
+  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz':
+    resolution: {integrity: sha512-iaAarHn1M9xlMsO5EGBmDcDhpO21hqu7rCZnuuvRmbX38h39j1SewQA2Y/Iv+X6vfCls8uIBvriSDDga+qYO7w==, tarball: https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz}
     version: 0.60.1
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
@@ -2651,7 +2651,7 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
+  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/92b8fe1b330c9211b210e72a8f72210f3b54d1eb/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.1)(zod@4.2.1)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.25.3
         version: 1.25.3(hono@4.11.1)(zod@4.2.1)
       '@smithery/api':
-        specifier: 0.59.0
-        version: 0.59.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
+        specifier: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz
+        version: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))
       '@smithery/sdk':
         specifier: ^4.1.0
         version: 4.1.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))(zod@4.2.1)
@@ -800,8 +800,9 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
-  '@smithery/api@0.59.0':
-    resolution: {integrity: sha512-CpXGjNHZ4x0SrLIkBCj9WG/FKgv/Qx72EDLXAIz7Jl1oUdpwD5we8kB3+41LSDhM/6vDJxBUPYbx0qA3dPQGJw==}
+  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz':
+    resolution: {integrity: sha512-8QELSglbj/tXG14rHc+Gjnn2QjplKbbgbn47NsG02QPcUHpzyDnGcKAXXejha0gmjlIcAj4M/Gtri0pTvlFkPA==, tarball: https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz}
+    version: 0.60.1
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
     peerDependenciesMeta:
@@ -2650,7 +2651,7 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@smithery/api@0.59.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
+  '@smithery/api@https://pkg.stainless.com/s/smithery-typescript/204eb9764c44a7a70b6f65f06adb94fa0d1547fe/dist.tar.gz(@modelcontextprotocol/sdk@1.25.3(hono@4.11.1)(zod@4.2.1))':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.1)(zod@4.2.1)
 

--- a/src/commands/__tests__/format-connection.test.ts
+++ b/src/commands/__tests__/format-connection.test.ts
@@ -68,4 +68,53 @@ describe("formatConnectionOutput", () => {
 
 		expect(output.iconUrl).toBeUndefined()
 	})
+
+	test("includes uplink transport and disconnected status", () => {
+		const output = formatConnectionOutput({
+			connectionId: "local-dev",
+			name: "local-dev",
+			mcpUrl: null,
+			transport: "uplink",
+			metadata: null,
+			status: {
+				state: "disconnected",
+			},
+		} as never)
+
+		expect(output).toMatchObject({
+			connectionId: "local-dev",
+			name: "local-dev",
+			mcpUrl: null,
+			transport: "uplink",
+			status: { state: "disconnected" },
+		})
+	})
+
+	test("omits non-uplink transport from CLI output", () => {
+		const output = formatConnectionOutput({
+			connectionId: "remote-http",
+			name: "remote-http",
+			mcpUrl: "https://server.smithery.ai/remote-http",
+			transport: "http",
+			metadata: null,
+			status: { state: "connected" },
+		} as never)
+
+		expect(output.transport).toBeUndefined()
+	})
+
+	test("preserves disconnected status payload", () => {
+		const output = formatConnectionOutput({
+			connectionId: "local-dev",
+			name: "local-dev",
+			mcpUrl: null,
+			transport: "uplink",
+			metadata: null,
+			status: {
+				state: "disconnected",
+			},
+		} as never)
+
+		expect(output.status).toEqual({ state: "disconnected" })
+	})
 })

--- a/src/commands/__tests__/mcp-add-uplink.test.ts
+++ b/src/commands/__tests__/mcp-add-uplink.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+	mockAddServerImpl,
+	mockCreateConnection,
+	mockSetConnection,
+	mockCreateSession,
+	mockServeUplink,
+} = vi.hoisted(() => {
+	const addServerImpl = vi.fn()
+	const createConnection = vi.fn()
+	const setConnection = vi.fn()
+	const createSession = vi.fn(async () => ({
+		createConnection,
+		setConnection,
+		getNamespace: () => "calclavia",
+	}))
+	const serveUplink = vi.fn(async () => 0)
+
+	return {
+		mockAddServerImpl: addServerImpl,
+		mockCreateConnection: createConnection,
+		mockSetConnection: setConnection,
+		mockCreateSession: createSession,
+		mockServeUplink: serveUplink,
+	}
+})
+
+vi.mock("../mcp/add-impl", () => ({
+	addServer: mockAddServerImpl,
+}))
+
+vi.mock("../mcp/api", () => ({
+	ConnectSession: {
+		create: mockCreateSession,
+	},
+}))
+
+vi.mock("../../lib/uplink", async () => {
+	const actual = await vi.importActual("../../lib/uplink")
+	return {
+		...actual,
+		serveUplink: mockServeUplink,
+	}
+})
+
+import { addServer } from "../mcp/add"
+
+describe("mcp add uplink routing", () => {
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore()
+		consoleErrorSpy.mockRestore()
+	})
+
+	test("upserts localhost URLs as uplink connections", async () => {
+		mockSetConnection.mockResolvedValue({
+			connectionId: "chrome",
+			name: "chrome",
+			transport: "uplink",
+			mcpUrl: null,
+			metadata: null,
+			status: { state: "disconnected" },
+		})
+
+		await addServer("http://127.0.0.1:9090/mcp", {
+			id: "chrome",
+		})
+
+		expect(mockSetConnection).toHaveBeenCalledWith("chrome", undefined, {
+			name: "chrome",
+			metadata: undefined,
+			transport: "uplink",
+		})
+		expect(mockServeUplink).toHaveBeenCalledWith({
+			connectionId: "chrome",
+			force: undefined,
+			namespace: "calclavia",
+			target: {
+				kind: "uplink-http",
+				mcpUrl: "http://127.0.0.1:9090/mcp",
+			},
+		})
+		expect(mockAddServerImpl).not.toHaveBeenCalled()
+	})
+
+	test("creates stdio uplink connections from commands passed after --", async () => {
+		mockCreateConnection.mockResolvedValue({
+			connectionId: "uplink-1",
+			name: "uplink-1",
+			transport: "uplink",
+			mcpUrl: null,
+			metadata: null,
+			status: { state: "disconnected" },
+		})
+
+		await addServer(undefined, {
+			uplinkCommand: ["npx", "-y", "@chromedevtools/chrome-devtools-mcp"],
+		} as never)
+
+		expect(mockCreateConnection).toHaveBeenCalledWith(undefined, {
+			name: undefined,
+			metadata: undefined,
+			transport: "uplink",
+		})
+		expect(mockServeUplink).toHaveBeenCalledWith({
+			connectionId: "uplink-1",
+			force: undefined,
+			namespace: "calclavia",
+			target: {
+				kind: "uplink-stdio",
+				command: "npx",
+				args: ["-y", "@chromedevtools/chrome-devtools-mcp"],
+			},
+		})
+		expect(mockAddServerImpl).not.toHaveBeenCalled()
+	})
+
+	test("rejects headers for uplink targets before hitting the api", async () => {
+		await expect(
+			addServer("http://127.0.0.1:9090/mcp", {
+				headers: '{"authorization":"Bearer nope"}',
+			}),
+		).rejects.toThrow("process.exit() was called")
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"--headers is not supported for uplink connections.",
+			),
+		)
+		expect(mockCreateConnection).not.toHaveBeenCalled()
+		expect(mockSetConnection).not.toHaveBeenCalled()
+		expect(mockServeUplink).not.toHaveBeenCalled()
+	})
+})

--- a/src/commands/__tests__/mcp-api.test.ts
+++ b/src/commands/__tests__/mcp-api.test.ts
@@ -1,0 +1,81 @@
+import { ConflictError } from "@smithery/api"
+import { describe, expect, test, vi } from "vitest"
+import { ConnectSession } from "../mcp/api"
+
+describe("ConnectSession uplink compatibility", () => {
+	test("creates uplink connections without an mcpUrl", async () => {
+		const post = vi.fn().mockResolvedValue({
+			connectionId: "local-dev",
+			name: "local-dev",
+			mcpUrl: null,
+			transport: "uplink",
+			metadata: null,
+			status: { state: "disconnected" },
+		})
+
+		const session = new ConnectSession({ post } as never, "calclavia")
+		await session.createConnection(undefined, {
+			name: "local-dev",
+			transport: "uplink",
+		})
+
+		expect(post).toHaveBeenCalledWith("/connect/calclavia", {
+			body: {
+				name: "local-dev",
+				transport: "uplink",
+			},
+		})
+	})
+
+	test("does not replace conflicting uplink connections on 409", async () => {
+		const conflict = new ConflictError(409, {}, undefined, new Headers())
+		const put = vi.fn().mockRejectedValueOnce(conflict)
+		const del = vi.fn().mockResolvedValue({ success: true })
+
+		const session = new ConnectSession(
+			{ put, delete: del } as never,
+			"calclavia",
+		)
+		await expect(
+			session.setConnection("local-dev", undefined, {
+				transport: "uplink",
+			}),
+		).rejects.toBe(conflict)
+
+		expect(put).toHaveBeenCalledWith("/connect/calclavia/local-dev", {
+			body: {
+				transport: "uplink",
+			},
+		})
+		expect(del).not.toHaveBeenCalled()
+	})
+
+	test("retries conflicting http set requests after deleting the connection", async () => {
+		const put = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new ConflictError(409, {}, undefined, new Headers()),
+			)
+			.mockResolvedValueOnce({
+				connectionId: "remote-http",
+				name: "remote-http",
+				mcpUrl: "https://server.smithery.ai/exa",
+				metadata: null,
+				status: { state: "connected" },
+			})
+		const del = vi.fn().mockResolvedValue({ success: true })
+
+		const session = new ConnectSession(
+			{ put, delete: del } as never,
+			"calclavia",
+		)
+		await session.setConnection("remote-http", "https://server.smithery.ai/exa")
+
+		expect(del).toHaveBeenCalledWith("/connect/calclavia/remote-http")
+		expect(put).toHaveBeenNthCalledWith(2, "/connect/calclavia/remote-http", {
+			body: {
+				mcpUrl: "https://server.smithery.ai/exa",
+			},
+		})
+	})
+})

--- a/src/commands/__tests__/uplink-target.test.ts
+++ b/src/commands/__tests__/uplink-target.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test, vi } from "vitest"
+import { classifyAddTarget, extractAddInvocation } from "../mcp/uplink-target"
+
+describe("extractAddInvocation", () => {
+	test("keeps a positional server when no uplink command is provided", () => {
+		const result = extractAddInvocation([
+			"node",
+			"cli",
+			"mcp",
+			"add",
+			"http://localhost:9090/mcp",
+			"--id",
+			"chrome",
+		])
+
+		expect(result).toEqual({
+			server: "http://localhost:9090/mcp",
+			commandTokens: [],
+		})
+	})
+
+	test("keeps a positional server when option values are passed inline", () => {
+		const result = extractAddInvocation([
+			"node",
+			"cli",
+			"mcp",
+			"add",
+			"--id=chrome",
+			"http://localhost:9090/mcp",
+		])
+
+		expect(result).toEqual({
+			server: "http://localhost:9090/mcp",
+			commandTokens: [],
+		})
+	})
+
+	test("extracts a stdio command passed after -- without inventing a server", () => {
+		const result = extractAddInvocation([
+			"node",
+			"cli",
+			"mcp",
+			"add",
+			"--id",
+			"chrome",
+			"--",
+			"npx",
+			"-y",
+			"foo",
+		])
+
+		expect(result).toEqual({
+			server: undefined,
+			commandTokens: ["npx", "-y", "foo"],
+		})
+	})
+
+	test("preserves an optional pre-command hint before --", () => {
+		const result = extractAddInvocation([
+			"node",
+			"cli",
+			"mcp",
+			"add",
+			"chrome",
+			"--",
+			"npx",
+			"-y",
+			"foo",
+		])
+
+		expect(result).toEqual({
+			server: "chrome",
+			commandTokens: ["npx", "-y", "foo"],
+		})
+	})
+
+	test("finds the actual mcp add command when the local command also contains add", () => {
+		const result = extractAddInvocation([
+			"node",
+			"cli",
+			"mcp",
+			"add",
+			"--",
+			"cargo",
+			"add",
+			"foo",
+		])
+
+		expect(result).toEqual({
+			server: undefined,
+			commandTokens: ["cargo", "add", "foo"],
+		})
+	})
+})
+
+describe("classifyAddTarget", () => {
+	test("treats stdio commands as uplink stdio targets", async () => {
+		const result = await classifyAddTarget({
+			commandTokens: ["npx", "-y", "@modelcontextprotocol/server-everything"],
+		})
+
+		expect(result).toEqual({
+			kind: "uplink-stdio",
+			command: "npx",
+			args: ["-y", "@modelcontextprotocol/server-everything"],
+		})
+	})
+
+	test("treats literal loopback URLs as uplink http targets", async () => {
+		const result = await classifyAddTarget({
+			server: "http://127.0.0.1:9090/mcp",
+		})
+
+		expect(result).toEqual({
+			kind: "uplink-http",
+			mcpUrl: "http://127.0.0.1:9090/mcp",
+		})
+	})
+
+	test("treats loopback-resolving hosts as uplink http targets", async () => {
+		const result = await classifyAddTarget(
+			{ server: "http://devbox:9090/mcp" },
+			{
+				lookup: vi
+					.fn()
+					.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]),
+			},
+		)
+
+		expect(result).toEqual({
+			kind: "uplink-http",
+			mcpUrl: "http://devbox:9090/mcp",
+		})
+	})
+
+	test("leaves non-loopback URLs on the normal http path", async () => {
+		const result = await classifyAddTarget(
+			{ server: "https://server.smithery.ai/exa" },
+			{
+				lookup: vi
+					.fn()
+					.mockResolvedValue([{ address: "34.117.59.81", family: 4 }]),
+			},
+		)
+
+		expect(result).toEqual({
+			kind: "http",
+			server: "https://server.smithery.ai/exa",
+		})
+	})
+})

--- a/src/commands/mcp/add-flow.ts
+++ b/src/commands/mcp/add-flow.ts
@@ -18,7 +18,7 @@ export async function finalizeAddedConnection(
 	},
 ): Promise<Connection> {
 	let current = connection
-	let currentUrl = connection.mcpUrl
+	let currentUrl = requireConnectionUrl(connection)
 	let headers = { ...(options.headers ?? {}) }
 
 	while (
@@ -36,7 +36,7 @@ export async function finalizeAddedConnection(
 			headers: Object.keys(headers).length > 0 ? headers : undefined,
 			unstableWebhookUrl: options.unstableWebhookUrl,
 		})
-		currentUrl = current.mcpUrl
+		currentUrl = requireConnectionUrl(current)
 	}
 
 	return current
@@ -52,6 +52,19 @@ export function buildDuplicateInputRequiredTip(
 	return [
 		"Remove and re-add to continue:",
 		`smithery mcp remove ${connection.connectionId}`,
-		buildInputRequiredAddCommand(connection.mcpUrl, connection.status),
+		buildInputRequiredAddCommand(
+			requireConnectionUrl(connection),
+			connection.status,
+		),
 	].join("\n")
+}
+
+function requireConnectionUrl(connection: Connection): string {
+	if (!connection.mcpUrl) {
+		throw new Error(
+			`Connection ${connection.connectionId} is missing an MCP URL.`,
+		)
+	}
+
+	return connection.mcpUrl
 }

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -23,12 +23,10 @@ export async function addServer(
 	},
 ): Promise<void> {
 	const target = await classifyAddTarget({
-/* DEBUG_ADD */
 		server,
 		commandTokens: options.uplinkCommand,
 	})
 
-	console.error("[DEBUG_ADD] target:", JSON.stringify(target))
 	if (target.kind !== "http") {
 		return addUplinkServer(target, options)
 	}

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -1,22 +1,40 @@
 import { fatal } from "../../lib/cli-error"
+import { serveUplink, type UplinkTarget } from "../../lib/uplink"
 import { finalizeAddedConnection } from "./add-flow"
 import { addServer as addServerImpl } from "./add-impl"
 import { ConnectSession } from "./api"
 import { normalizeMcpUrl } from "./normalize-url"
 import { outputConnectionDetail } from "./output-connection"
 import { parseJsonObject } from "./parse-json"
+import { classifyAddTarget } from "./uplink-target"
 
 export async function addServer(
-	mcpUrl: string,
+	server: string | undefined,
 	options: {
 		id?: string
 		name?: string
 		namespace?: string
 		metadata?: string
 		headers?: string
+		config?: string
+		force?: boolean
+		uplinkCommand?: string[]
 		unstableWebhookUrl?: string
 	},
 ): Promise<void> {
+	const target = await classifyAddTarget({
+/* DEBUG_ADD */
+		server,
+		commandTokens: options.uplinkCommand,
+	})
+
+	console.error("[DEBUG_ADD] target:", JSON.stringify(target))
+	if (target.kind !== "http") {
+		return addUplinkServer(target, options)
+	}
+
+	const mcpUrl = target.server
+
 	// If id is set but name is not, default name to id
 	const name = options.name ?? options.id
 
@@ -61,4 +79,66 @@ export async function addServer(
 	}
 	// Use create for auto-generated ID
 	return addServerImpl(mcpUrl, { ...options, name })
+}
+
+async function addUplinkServer(
+	target: UplinkTarget,
+	options: {
+		id?: string
+		name?: string
+		namespace?: string
+		metadata?: string
+		headers?: string
+		config?: string
+		force?: boolean
+		unstableWebhookUrl?: string
+	},
+): Promise<void> {
+	try {
+		if (options.headers !== undefined) {
+			throw new Error("--headers is not supported for uplink connections.")
+		}
+
+		if (options.config) {
+			throw new Error("--config is not supported for uplink connections.")
+		}
+
+		if (options.unstableWebhookUrl) {
+			throw new Error(
+				"--unstableWebhookUrl is not supported for uplink connections.",
+			)
+		}
+
+		const parsedMetadata = parseJsonObject(options.metadata, "Metadata")
+		const name = options.name ?? options.id
+		const session = await ConnectSession.create(options.namespace)
+		const connection = options.id
+			? await session.setConnection(options.id, undefined, {
+					name,
+					metadata: parsedMetadata,
+					transport: "uplink",
+				})
+			: await session.createConnection(undefined, {
+					name,
+					metadata: parsedMetadata,
+					transport: "uplink",
+				})
+
+		const namespace = session.getNamespace()
+		console.log(
+			`Creating connection ${namespace}/${connection.connectionId} ... ok`,
+		)
+
+		const exitCode = await serveUplink({
+			namespace,
+			connectionId: connection.connectionId,
+			target,
+			force: options.force,
+		})
+		if (exitCode !== 0) {
+			process.exit(exitCode)
+		}
+	} catch (error) {
+		fatal("Failed to add connection", error)
+	}
 }

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -6,8 +6,10 @@ import {
 	createConnection as createSmitheryConnection,
 } from "@smithery/api/mcp"
 import type {
-	Connection as SmitheryConnection,
-	ConnectionsListResponse as SmitheryConnectionsListResponse,
+	Connection,
+	ConnectionCreateParams,
+	ConnectionListParams,
+	ConnectionsListResponse,
 } from "@smithery/api/resources/connections/connections.js"
 import { createSmitheryClient } from "../../lib/smithery-client"
 import {
@@ -15,22 +17,8 @@ import {
 	setNamespace,
 } from "../../utils/smithery-settings"
 
-export type ConnectionTransport = "http" | "uplink"
-export type ConnectionStatus =
-	| NonNullable<SmitheryConnection["status"]>
-	| { state: "disconnected" }
-
-export interface Connection
-	extends Omit<SmitheryConnection, "mcpUrl" | "status"> {
-	mcpUrl: string | null
-	status?: ConnectionStatus
-	transport?: ConnectionTransport
-}
-
-export interface ConnectionsListResponse
-	extends Omit<SmitheryConnectionsListResponse, "connections"> {
-	connections: Connection[]
-}
+export type { Connection, ConnectionsListResponse }
+export type ConnectionTransport = NonNullable<Connection["transport"]>
 
 export interface ToolInfo extends Tool {
 	connectionId: string
@@ -40,13 +28,15 @@ export interface ToolInfo extends Tool {
 // Use Awaited to get the concrete type from createSmitheryClient
 type SmitheryClient = Awaited<ReturnType<typeof createSmitheryClient>>
 
-type ConnectionWriteOptions = {
-	name?: string
-	metadata?: Record<string, unknown>
-	headers?: Record<string, string>
+type ConnectionWriteOptions = Pick<
+	ConnectionCreateParams,
+	"name" | "metadata" | "headers" | "transport"
+> & {
 	unstableWebhookUrl?: string
-	transport?: ConnectionTransport
 }
+
+type ConnectionsListQuery = ConnectionListParams &
+	Record<`metadata.${string}`, string>
 
 /**
  * Session for Connect operations that reuses clients within a command.
@@ -256,7 +246,7 @@ export class ConnectSession {
 		})
 	}
 
-	private requestConnectionsList(query?: Record<string, unknown>) {
+	private requestConnectionsList(query?: ConnectionsListQuery) {
 		return this.smitheryClient.get<ConnectionsListResponse>(
 			connectCollectionPath(this.namespace),
 			{ query },
@@ -268,7 +258,6 @@ function buildConnectionBody(
 	mcpUrl: string | undefined,
 	options: ConnectionWriteOptions,
 ): Record<string, unknown> {
-	/* DEBUG_BCB */
 	const body = {
 		...(mcpUrl ? { mcpUrl } : {}),
 		...(options.name ? { name: options.name } : {}),

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -279,7 +279,6 @@ function buildConnectionBody(
 			unstableWebhookUrl: options.unstableWebhookUrl,
 		}),
 	}
-	console.error('[DEBUG_BCB] body:', JSON.stringify(body), 'mcpUrl arg:', JSON.stringify(mcpUrl), 'options:', JSON.stringify(options))
 	return body
 }
 

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -1,19 +1,36 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import type { Tool } from "@modelcontextprotocol/sdk/types.js"
+import { ConflictError } from "@smithery/api"
 import {
 	type CreateConnectionOptions,
 	createConnection as createSmitheryConnection,
 } from "@smithery/api/mcp"
 import type {
-	Connection,
-	ConnectionsListResponse,
+	Connection as SmitheryConnection,
+	ConnectionsListResponse as SmitheryConnectionsListResponse,
 } from "@smithery/api/resources/connections/connections.js"
 import { createSmitheryClient } from "../../lib/smithery-client"
 import {
 	getNamespace as getStoredNamespace,
 	setNamespace,
 } from "../../utils/smithery-settings"
-export type { Connection, ConnectionsListResponse }
+
+export type ConnectionTransport = "http" | "uplink"
+export type ConnectionStatus =
+	| NonNullable<SmitheryConnection["status"]>
+	| { state: "disconnected" }
+
+export interface Connection
+	extends Omit<SmitheryConnection, "mcpUrl" | "status"> {
+	mcpUrl: string | null
+	status?: ConnectionStatus
+	transport?: ConnectionTransport
+}
+
+export interface ConnectionsListResponse
+	extends Omit<SmitheryConnectionsListResponse, "connections"> {
+	connections: Connection[]
+}
 
 export interface ToolInfo extends Tool {
 	connectionId: string
@@ -22,9 +39,14 @@ export interface ToolInfo extends Tool {
 
 // Use Awaited to get the concrete type from createSmitheryClient
 type SmitheryClient = Awaited<ReturnType<typeof createSmitheryClient>>
-type ListConnectionsParams = Parameters<
-	SmitheryClient["connections"]["list"]
->[1]
+
+type ConnectionWriteOptions = {
+	name?: string
+	metadata?: Record<string, unknown>
+	headers?: Record<string, string>
+	unstableWebhookUrl?: string
+	transport?: ConnectionTransport
+}
 
 /**
  * Session for Connect operations that reuses clients within a command.
@@ -44,10 +66,14 @@ export class ConnectSession {
 		return new ConnectSession(client, ns)
 	}
 
+	getNamespace(): string {
+		return this.namespace
+	}
+
 	async listConnectionsByUrl(
 		mcpUrl: string,
 	): Promise<{ connections: Connection[] }> {
-		const data = await this.smitheryClient.connections.list(this.namespace, {
+		const data = await this.requestConnectionsList({
 			mcpUrl,
 		})
 		return { connections: data.connections }
@@ -62,11 +88,11 @@ export class ConnectSession {
 
 		// Explicit cursor: return a single page (manual pagination)
 		if (options?.cursor) {
-			const data = await this.smitheryClient.connections.list(this.namespace, {
+			const data = await this.requestConnectionsList({
 				limit: options.limit,
 				cursor: options.cursor,
 				...metadataQuery,
-			} as ListConnectionsParams)
+			})
 			return {
 				connections: data.connections,
 				nextCursor: data.nextCursor,
@@ -78,10 +104,10 @@ export class ConnectSession {
 		let cursor: string | undefined
 
 		do {
-			const data = await this.smitheryClient.connections.list(this.namespace, {
+			const data = await this.requestConnectionsList({
 				cursor,
 				...metadataQuery,
-			} as ListConnectionsParams)
+			})
 			all.push(...data.connections)
 			cursor = data.nextCursor ?? undefined
 		} while (cursor && (!options?.limit || all.length < options.limit))
@@ -164,23 +190,15 @@ export class ConnectSession {
 	}
 
 	async createConnection(
-		mcpUrl: string,
-		options: {
-			name?: string
-			metadata?: Record<string, unknown>
-			headers?: Record<string, string>
-			unstableWebhookUrl?: string
-		} = {},
+		mcpUrl?: string,
+		options: ConnectionWriteOptions = {},
 	): Promise<Connection> {
-		return this.smitheryClient.connections.create(this.namespace, {
-			mcpUrl,
-			name: options.name,
-			metadata: options.metadata,
-			headers: options.headers,
-			...(options.unstableWebhookUrl && {
-				unstableWebhookUrl: options.unstableWebhookUrl,
-			}),
-		} as Parameters<typeof this.smitheryClient.connections.create>[1])
+		return this.smitheryClient.post<Connection>(
+			connectCollectionPath(this.namespace),
+			{
+				body: buildConnectionBody(mcpUrl, options),
+			},
+		)
 	}
 
 	/**
@@ -190,44 +208,39 @@ export class ConnectSession {
 	async setConnection(
 		connectionId: string,
 		mcpUrl?: string,
-		options: {
-			name?: string
-			metadata?: Record<string, unknown>
-			headers?: Record<string, string>
-			unstableWebhookUrl?: string
-		} = {},
+		options: ConnectionWriteOptions = {},
 	): Promise<Connection> {
-		const params = {
-			namespace: this.namespace,
-			...(mcpUrl ? { mcpUrl } : {}),
-			name: options.name,
-			metadata: options.metadata,
-			headers: options.headers,
-			...(options.unstableWebhookUrl && {
-				unstableWebhookUrl: options.unstableWebhookUrl,
-			}),
-		} as Parameters<typeof this.smitheryClient.connections.set>[1]
 		try {
-			return this.smitheryClient.connections.set(connectionId, params)
+			return await this.smitheryClient.put<Connection>(
+				connectItemPath(this.namespace, connectionId),
+				{
+					body: buildConnectionBody(mcpUrl, options),
+				},
+			)
 		} catch (error) {
-			if (error instanceof Error && error.message.includes("409")) {
+			if (error instanceof ConflictError && options.transport !== "uplink") {
 				await this.deleteConnection(connectionId)
-				return this.smitheryClient.connections.set(connectionId, params)
+				return this.smitheryClient.put<Connection>(
+					connectItemPath(this.namespace, connectionId),
+					{
+						body: buildConnectionBody(mcpUrl, options),
+					},
+				)
 			}
 			throw error
 		}
 	}
 
 	async deleteConnection(connectionId: string): Promise<void> {
-		await this.smitheryClient.connections.delete(connectionId, {
-			namespace: this.namespace,
-		})
+		await this.smitheryClient.delete(
+			connectItemPath(this.namespace, connectionId),
+		)
 	}
 
 	async getConnection(connectionId: string): Promise<Connection> {
-		return this.smitheryClient.connections.get(connectionId, {
-			namespace: this.namespace,
-		})
+		return this.smitheryClient.get<Connection>(
+			connectItemPath(this.namespace, connectionId),
+		)
 	}
 
 	async pollEvents(connectionId: string, options?: { limit?: number }) {
@@ -242,6 +255,40 @@ export class ConnectSession {
 			query: options?.limit ? { limit: options.limit } : undefined,
 		})
 	}
+
+	private requestConnectionsList(query?: Record<string, unknown>) {
+		return this.smitheryClient.get<ConnectionsListResponse>(
+			connectCollectionPath(this.namespace),
+			{ query },
+		)
+	}
+}
+
+function buildConnectionBody(
+	mcpUrl: string | undefined,
+	options: ConnectionWriteOptions,
+): Record<string, unknown> {
+	/* DEBUG_BCB */
+	const body = {
+		...(mcpUrl ? { mcpUrl } : {}),
+		...(options.name ? { name: options.name } : {}),
+		...(options.metadata ? { metadata: options.metadata } : {}),
+		...(options.headers ? { headers: options.headers } : {}),
+		...(options.transport ? { transport: options.transport } : {}),
+		...(options.unstableWebhookUrl && {
+			unstableWebhookUrl: options.unstableWebhookUrl,
+		}),
+	}
+	console.error('[DEBUG_BCB] body:', JSON.stringify(body), 'mcpUrl arg:', JSON.stringify(mcpUrl), 'options:', JSON.stringify(options))
+	return body
+}
+
+function connectCollectionPath(namespace: string): string {
+	return `/connect/${encodeURIComponent(namespace)}`
+}
+
+function connectItemPath(namespace: string, connectionId: string): string {
+	return `${connectCollectionPath(namespace)}/${encodeURIComponent(connectionId)}`
 }
 
 function toMetadataQuery(

--- a/src/commands/mcp/format-connection.ts
+++ b/src/commands/mcp/format-connection.ts
@@ -18,6 +18,10 @@ export function formatConnectionOutput(
 		status: formatStatus(connection.status),
 	}
 
+	if (connection.transport === "uplink") {
+		output.transport = connection.transport
+	}
+
 	if (connection.createdAt) {
 		output.createdAt = connection.createdAt
 	}
@@ -40,8 +44,8 @@ function formatStatus(
 		return "unknown"
 	}
 
-	if (status.state === "connected") {
-		return { state: "connected" }
+	if (status.state === "connected" || status.state === "disconnected") {
+		return { state: status.state }
 	}
 
 	if (status.state === "auth_required") {

--- a/src/commands/mcp/output-connection.ts
+++ b/src/commands/mcp/output-connection.ts
@@ -21,7 +21,7 @@ export function outputConnectionDetail(options: {
 		return
 	}
 
-	const rows = [
+	const rows: Array<[string, string | null]> = [
 		["connectionId", connection.connectionId],
 		["name", connection.name],
 		["mcpUrl", connection.mcpUrl],

--- a/src/commands/mcp/uplink-target.ts
+++ b/src/commands/mcp/uplink-target.ts
@@ -1,0 +1,172 @@
+import { lookup as dnsLookup } from "node:dns/promises"
+import { isIP } from "node:net"
+
+type LookupResult = Array<{ address: string; family: number }>
+
+type LookupFn = (hostname: string) => Promise<LookupResult>
+
+export type AddInvocation = {
+	server?: string
+	commandTokens: string[]
+}
+
+export type AddTarget =
+	| {
+			kind: "http"
+			server: string
+	  }
+	| {
+			kind: "uplink-http"
+			mcpUrl: string
+	  }
+	| {
+			kind: "uplink-stdio"
+			command: string
+			args: string[]
+	  }
+
+const OPTIONS_WITH_VALUES = new Set([
+	"--id",
+	"--name",
+	"--metadata",
+	"--headers",
+	"--namespace",
+	"--unstableWebhookUrl",
+	"-c",
+	"--client",
+	"--config",
+])
+
+export function extractAddInvocation(rawArgs: string[]): AddInvocation {
+	const addIndex = findAddCommandIndex(rawArgs)
+	if (addIndex < 0) {
+		return { commandTokens: [] }
+	}
+
+	const afterAdd = rawArgs.slice(addIndex + 1)
+	const dashIndex = afterAdd.indexOf("--")
+	const beforeDash =
+		dashIndex >= 0 ? afterAdd.slice(0, dashIndex) : afterAdd.slice()
+	const commandTokens = dashIndex >= 0 ? afterAdd.slice(dashIndex + 1) : []
+	const [server] = collectOperands(beforeDash)
+
+	return { server, commandTokens }
+}
+
+export async function classifyAddTarget(
+	input: Partial<AddInvocation>,
+	options: { lookup?: LookupFn } = {},
+): Promise<AddTarget> {
+	const commandTokens = input.commandTokens ?? []
+
+	if (commandTokens.length > 0) {
+		const [command, ...args] = commandTokens
+		return {
+			kind: "uplink-stdio",
+			command,
+			args,
+		}
+	}
+
+	if (!input.server) {
+		throw new Error("Missing server URL or local command.")
+	}
+
+	if (!isHttpUrl(input.server)) {
+		return {
+			kind: "http",
+			server: input.server,
+		}
+	}
+
+	const url = new URL(input.server)
+	const isLoopback = await resolvesToLoopback(url.hostname, options.lookup)
+	if (!isLoopback) {
+		return {
+			kind: "http",
+			server: input.server,
+		}
+	}
+
+	return {
+		kind: "uplink-http",
+		mcpUrl: input.server,
+	}
+}
+
+function collectOperands(tokens: string[]): string[] {
+	const operands: string[] = []
+
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index]
+		if (!token) {
+			continue
+		}
+
+		if (!token.startsWith("-")) {
+			operands.push(token)
+			continue
+		}
+
+		const [flag] = token.split("=", 1)
+		if (OPTIONS_WITH_VALUES.has(flag) && !token.includes("=")) {
+			index += 1
+		}
+	}
+
+	return operands
+}
+
+function isHttpUrl(value: string): boolean {
+	return value.startsWith("http://") || value.startsWith("https://")
+}
+
+async function resolvesToLoopback(
+	hostname: string,
+	lookup: LookupFn = defaultLookup,
+): Promise<boolean> {
+	const normalized =
+		hostname.startsWith("[") && hostname.endsWith("]")
+			? hostname.slice(1, -1)
+			: hostname
+
+	if (isLoopbackAddress(normalized)) {
+		return true
+	}
+
+	if (isIP(normalized) !== 0) {
+		return false
+	}
+
+	try {
+		const addresses = await lookup(normalized)
+		return (
+			addresses.length > 0 &&
+			addresses.every((entry) => isLoopbackAddress(entry.address))
+		)
+	} catch {
+		return false
+	}
+}
+
+async function defaultLookup(hostname: string): Promise<LookupResult> {
+	return dnsLookup(hostname, { all: true, verbatim: true })
+}
+
+function isLoopbackAddress(address: string): boolean {
+	if (address === "localhost" || address === "::1") {
+		return true
+	}
+
+	return /^127\.\d+\.\d+\.\d+$/.test(address)
+}
+
+function findAddCommandIndex(rawArgs: string[]): number {
+	for (let index = 0; index < rawArgs.length - 1; index += 1) {
+		if (rawArgs[index] === "mcp" && rawArgs[index + 1] === "add") {
+			return index + 1
+		}
+	}
+
+	return -1
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,12 +309,10 @@ async function handleCallTool(
 }
 
 async function handleMcpAdd(
-/* DEBUG_UPLINK_MARKER */
 	server: string | undefined,
 	options: CliOptions,
 	command: Command,
 ) {
-	console.error('[DEBUG] process.argv:', JSON.stringify(process.argv))
 	const { extractAddInvocation } = await import("./commands/mcp/uplink-target")
 	const rootCommand = command.parent?.parent ?? command.parent ?? command
 	const invocation = extractAddInvocation(

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ interface CliOptions {
 	config?: string
 	transport?: string
 	out?: string
+	id?: string
 	name?: string
 	resume?: boolean
 	configSchema?: string
@@ -38,13 +39,17 @@ interface CliOptions {
 	namespace?: string
 	organization?: string
 	metadata?: string
+	headers?: string
 	agent?: string
 	global?: boolean
 	yes?: boolean
 	body?: string
+	force?: boolean
 	up?: boolean
 	down?: boolean
 	model?: string
+	unstableWebhookUrl?: string
+	uplinkCommand?: string[]
 }
 
 interface ToolFindOptions extends CliOptions {
@@ -243,7 +248,10 @@ async function handleUninstall(
 
 const loadConnectCommands = () => import("./commands/mcp")
 
-async function handleAddConnection(server: string, options: CliOptions) {
+async function handleAddConnection(
+	server: string | undefined,
+	options: CliOptions,
+) {
 	const { addServer } = await loadConnectCommands()
 	await addServer(server, options)
 }
@@ -300,12 +308,35 @@ async function handleCallTool(
 	await callTool(connection, toolName, args, options)
 }
 
-async function handleMcpAdd(server: string, options: CliOptions) {
+async function handleMcpAdd(
+/* DEBUG_UPLINK_MARKER */
+	server: string | undefined,
+	options: CliOptions,
+	command: Command,
+) {
+	console.error('[DEBUG] process.argv:', JSON.stringify(process.argv))
+	const { extractAddInvocation } = await import("./commands/mcp/uplink-target")
+	const rootCommand = command.parent?.parent ?? command.parent ?? command
+	const invocation = extractAddInvocation(
+		(rootCommand as Command & { rawArgs?: string[] }).rawArgs ?? process.argv,
+	)
+	const parsedServer =
+		invocation.commandTokens.length > 0 ? invocation.server : server
+
 	if (options.client) {
-		await handleInstall(server, options)
+		if (invocation.commandTokens.length > 0) {
+			fatal("Local commands passed after -- are not supported with --client.")
+		}
+		if (!parsedServer) {
+			fatal("Server is required when using --client.")
+		}
+		await handleInstall(parsedServer, options)
 		return
 	}
-	await handleAddConnection(server, options)
+	await handleAddConnection(parsedServer, {
+		...options,
+		uplinkCommand: invocation.commandTokens,
+	})
 }
 
 async function handleMcpRemove(ids: string[], options: CliOptions) {
@@ -561,7 +592,8 @@ Examples:
 mcpCmd.commandsGroup("Connections:")
 
 mcpCmd
-	.command("add <server>")
+	.command("add [server]")
+	.allowExcessArguments(true)
 	.description("Add an MCP server connection")
 	.option(
 		"--id <id>",
@@ -573,7 +605,7 @@ mcpCmd
 	.option("--namespace <ns>", "Target namespace")
 	.option(
 		"--force",
-		"Create a new connection even if one already exists for this URL",
+		"Create a duplicate HTTP connection, or take over an existing uplink pair",
 	)
 	.option(
 		"--unstableWebhookUrl <url>",
@@ -592,6 +624,8 @@ mcpCmd
 		`
 Examples:
   smithery mcp add https://server.smithery.ai/exa
+  smithery mcp add http://localhost:9090/mcp --id chrome
+  smithery mcp add --id chrome -- npx -y @chromedevtools/chrome-devtools-mcp
   smithery mcp add https://server.smithery.ai/exa --id exa --name "Exa Search"
   smithery mcp add anthropic/exa --client claude`,
 	)

--- a/src/lib/__tests__/uplink.test.ts
+++ b/src/lib/__tests__/uplink.test.ts
@@ -1,0 +1,160 @@
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js"
+import { describe, expect, test, vi } from "vitest"
+import { wireJsonRpcBridge } from "../uplink"
+
+function createSocketPeer() {
+	const listeners: {
+		message?: (data: string | ArrayBuffer) => void
+		close?: (event: { code: number; reason: string }) => void
+		error?: (error: unknown) => void
+	} = {}
+
+	return {
+		sent: [] as string[],
+		onMessage(listener: (data: string | ArrayBuffer) => void) {
+			listeners.message = listener
+			return undefined
+		},
+		onClose(listener: (event: { code: number; reason: string }) => void) {
+			listeners.close = listener
+			return undefined
+		},
+		onError(listener: (error: unknown) => void) {
+			listeners.error = listener
+			return undefined
+		},
+		send(text: string) {
+			this.sent.push(text)
+		},
+		emitMessage(data: string | ArrayBuffer) {
+			listeners.message?.(data)
+		},
+		emitClose(event: { code: number; reason: string }) {
+			listeners.close?.(event)
+		},
+		emitError(error: unknown) {
+			listeners.error?.(error)
+		},
+	}
+}
+
+function createLocalPeer() {
+	const listeners: {
+		message?: (message: JSONRPCMessage) => void
+		close?: (code?: number) => void
+		error?: (error: unknown) => void
+	} = {}
+
+	return {
+		sent: [] as JSONRPCMessage[],
+		onMessage(listener: (message: JSONRPCMessage) => void) {
+			listeners.message = listener
+			return undefined
+		},
+		onClose(listener: (code?: number) => void) {
+			listeners.close = listener
+			return undefined
+		},
+		onError(listener: (error: unknown) => void) {
+			listeners.error = listener
+			return undefined
+		},
+		async send(message: JSONRPCMessage) {
+			this.sent.push(message)
+		},
+		emitMessage(message: JSONRPCMessage) {
+			listeners.message?.(message)
+		},
+		emitClose(code?: number) {
+			listeners.close?.(code)
+		},
+		emitError(error: unknown) {
+			listeners.error?.(error)
+		},
+	}
+}
+
+describe("wireJsonRpcBridge", () => {
+	test("forwards frames in both directions without changing payloads", async () => {
+		const socket = createSocketPeer()
+		const local = createLocalPeer()
+		const onClose = vi.fn()
+		const onError = vi.fn()
+
+		wireJsonRpcBridge({ socket, local, onClose, onError })
+
+		const response = {
+			jsonrpc: "2.0",
+			id: 1,
+			result: { ok: true },
+		} satisfies JSONRPCMessage
+		local.emitMessage(response)
+
+		expect(socket.sent).toEqual([JSON.stringify(response)])
+
+		const request = {
+			jsonrpc: "2.0",
+			id: 2,
+			method: "tools/list",
+		} satisfies JSONRPCMessage
+		socket.emitMessage(JSON.stringify(request))
+
+		expect(local.sent).toEqual([request])
+		expect(onError).not.toHaveBeenCalled()
+		expect(onClose).not.toHaveBeenCalled()
+	})
+
+	test("accepts websocket binary frames and reports invalid json", async () => {
+		const socket = createSocketPeer()
+		const local = createLocalPeer()
+		const onClose = vi.fn()
+		const onError = vi.fn()
+
+		wireJsonRpcBridge({ socket, local, onClose, onError })
+
+		const binaryMessage = new TextEncoder().encode(
+			JSON.stringify({
+				jsonrpc: "2.0",
+				method: "notifications/initialized",
+			}),
+		).buffer
+		socket.emitMessage(binaryMessage)
+
+		expect(local.sent).toEqual([
+			{
+				jsonrpc: "2.0",
+				method: "notifications/initialized",
+			},
+		])
+
+		socket.emitMessage("{")
+		await vi.waitFor(() => {
+			expect(onError).toHaveBeenCalledWith(
+				expect.objectContaining({ source: "socket" }),
+			)
+		})
+	})
+
+	test("tags socket and local transport errors separately", () => {
+		const socket = createSocketPeer()
+		const local = createLocalPeer()
+		const onClose = vi.fn()
+		const onError = vi.fn()
+
+		wireJsonRpcBridge({ socket, local, onClose, onError })
+
+		const socketError = new Error("socket failed")
+		socket.emitError(socketError)
+		expect(onError).toHaveBeenCalledWith({
+			source: "socket",
+			error: socketError,
+		})
+
+		const localError = new Error("local failed")
+		local.emitError(localError)
+		expect(onError).toHaveBeenCalledWith({
+			source: "local",
+			error: localError,
+		})
+	})
+})

--- a/src/lib/uplink.ts
+++ b/src/lib/uplink.ts
@@ -1,0 +1,756 @@
+import { spawn } from "node:child_process"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import {
+	ReadBuffer,
+	serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js"
+import {
+	type JSONRPCMessage,
+	JSONRPCMessageSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import pc from "picocolors"
+import { getRuntimeEnvironment } from "../utils/runtime"
+import { createSmitheryClient } from "./smithery-client"
+
+const MAX_RETRIES = 5
+const RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000]
+const STDIO_KILL_TIMEOUT_MS = 5000
+
+export type UplinkTarget =
+	| {
+			kind: "uplink-http"
+			mcpUrl: string
+	  }
+	| {
+			kind: "uplink-stdio"
+			command: string
+			args: string[]
+	  }
+
+type BridgeSocketPeer = {
+	onMessage(
+		listener: (data: string | ArrayBuffer) => void,
+	): (() => void) | undefined
+	onClose(
+		listener: (event: { code: number; reason: string }) => void,
+	): (() => void) | undefined
+	onError(listener: (error: unknown) => void): (() => void) | undefined
+	send(text: string): void
+}
+
+type BridgeLocalPeer = {
+	onMessage(
+		listener: (message: JSONRPCMessage) => void,
+	): (() => void) | undefined
+	onClose(listener: (code?: number) => void): (() => void) | undefined
+	onError(listener: (error: unknown) => void): (() => void) | undefined
+	send(message: JSONRPCMessage): Promise<void>
+}
+
+type ManagedLocalPeer = BridgeLocalPeer & {
+	close(): Promise<void>
+	start(): Promise<void>
+}
+
+type BridgeCloseEvent =
+	| { source: "socket"; code: number; reason: string }
+	| { source: "local"; code?: number }
+
+type BridgeErrorEvent =
+	| { source: "socket"; error: unknown }
+	| { source: "local"; error: unknown }
+
+export function wireJsonRpcBridge(options: {
+	socket: BridgeSocketPeer
+	local: BridgeLocalPeer
+	onClose: (event: BridgeCloseEvent) => void
+	onError: (event: BridgeErrorEvent) => void
+}): () => void {
+	const { socket, local, onClose, onError } = options
+	const textDecoder = new TextDecoder()
+	const cleanups: Array<() => void> = []
+
+	const addCleanup = (cleanup: (() => void) | undefined) => {
+		if (typeof cleanup === "function") {
+			cleanups.push(cleanup)
+		}
+	}
+
+	addCleanup(
+		socket.onMessage((data) => {
+			void (async () => {
+				const text =
+					typeof data === "string"
+						? data
+						: textDecoder.decode(new Uint8Array(data))
+				let message: JSONRPCMessage
+				try {
+					message = JSONRPCMessageSchema.parse(JSON.parse(text))
+				} catch (error) {
+					onError({ source: "socket", error })
+					return
+				}
+
+				try {
+					await local.send(message)
+				} catch (error) {
+					onError({ source: "local", error })
+				}
+			})()
+		}),
+	)
+
+	addCleanup(
+		local.onMessage((message) => {
+			try {
+				socket.send(JSON.stringify(message))
+			} catch (error) {
+				onError({ source: "socket", error })
+			}
+		}),
+	)
+
+	addCleanup(
+		socket.onClose((event) => {
+			onClose({
+				source: "socket",
+				code: event.code,
+				reason: event.reason,
+			})
+		}),
+	)
+
+	addCleanup(
+		local.onClose((code) => {
+			onClose({
+				source: "local",
+				code,
+			})
+		}),
+	)
+
+	addCleanup(
+		socket.onError((error) => {
+			onError({ source: "socket", error })
+		}),
+	)
+	addCleanup(
+		local.onError((error) => {
+			onError({ source: "local", error })
+		}),
+	)
+
+	return () => {
+		for (const cleanup of cleanups.splice(0)) {
+			cleanup()
+		}
+	}
+}
+
+export async function serveUplink(options: {
+	namespace: string
+	connectionId: string
+	target: UplinkTarget
+	force?: boolean
+}): Promise<number> {
+	const client = await createSmitheryClient()
+	const local: ManagedLocalPeer =
+		options.target.kind === "uplink-http"
+			? createHttpLocalPeer(options.target.mcpUrl)
+			: createStdioLocalPeer(options.target.command, options.target.args)
+
+	let activeSocket: WebSocket | null = null
+	let disposeBridge: (() => void) | undefined
+	let shuttingDown = false
+	let pairedOnce = false
+	const done = createDeferred<number>()
+
+	const stop = async (exitCode: number) => {
+		if (shuttingDown) {
+			return
+		}
+
+		shuttingDown = true
+		disposeBridge?.()
+		disposeBridge = undefined
+
+		removeSignalHandlers()
+
+		if (activeSocket) {
+			try {
+				activeSocket.close(1000, "closing")
+			} catch {
+				// Ignore close errors during shutdown.
+			}
+			activeSocket = null
+		}
+
+		await local.close().catch(() => {
+			// Ignore cleanup failures during shutdown.
+		})
+
+		done.resolve(exitCode)
+	}
+
+	const handleSignal = () => {
+		void stop(0)
+	}
+
+	const removeSignalHandlers = () => {
+		process.off("SIGINT", handleSignal)
+		process.off("SIGTERM", handleSignal)
+	}
+
+	process.on("SIGINT", handleSignal)
+	process.on("SIGTERM", handleSignal)
+
+	if (options.target.kind === "uplink-stdio") {
+		console.log(
+			`Local command: ${formatShellCommand(
+				options.target.command,
+				options.target.args,
+			)}`,
+		)
+	}
+
+	const connect = async (attempt: number) => {
+		const socket = await pairUplinkSocket({
+			baseURL: client.baseURL,
+			apiKey: client.apiKey,
+			namespace: options.namespace,
+			connectionId: options.connectionId,
+			force: options.force || attempt > 0,
+		})
+
+		activeSocket = socket
+		disposeBridge?.()
+
+		const socketPeer = createSocketPeer(socket)
+		disposeBridge = wireJsonRpcBridge({
+			socket: socketPeer,
+			local,
+			onError: (event) => {
+				if (shuttingDown) {
+					return
+				}
+
+				if (event.source === "socket") {
+					console.error(pc.yellow(formatError(event.error)))
+					if (
+						activeSocket === socket &&
+						socket.readyState < WebSocket.CLOSING
+					) {
+						socket.close()
+					}
+					return
+				}
+
+				console.error(pc.red(formatError(event.error)))
+				void stop(1)
+			},
+			onClose: (event) => {
+				disposeBridge?.()
+				disposeBridge = undefined
+				activeSocket = null
+
+				if (shuttingDown) {
+					return
+				}
+
+				if (event.source === "local") {
+					void stop(event.code ?? 1)
+					return
+				}
+
+				if (event.code === 1001 && event.reason === "replaced") {
+					console.error(pc.yellow("Uplink replaced by another session."))
+					void stop(1)
+					return
+				}
+
+				if (attempt >= MAX_RETRIES) {
+					console.error(pc.red("Uplink disconnected. Retry limit exceeded."))
+					void stop(1)
+					return
+				}
+
+				const nextAttempt = attempt + 1
+				const delayMs =
+					RETRY_DELAYS_MS[Math.min(nextAttempt - 1, RETRY_DELAYS_MS.length - 1)]
+				console.error(
+					pc.yellow(
+						`Uplink disconnected. Reconnecting (${nextAttempt}/${MAX_RETRIES}) in ${delayMs}ms...`,
+					),
+				)
+				void delay(delayMs)
+					.then(() => connect(nextAttempt))
+					.catch((error) => {
+						console.error(pc.red(formatError(error)))
+						void stop(1)
+					})
+			},
+		})
+
+		if (!pairedOnce) {
+			pairedOnce = true
+			console.log("Pairing uplink ... connected")
+			console.log(`Local MCP: ${describeLocalTarget(options.target)}`)
+			console.log(
+				`Smithery: ${options.namespace}/${options.connectionId} (${getConnectionUrl(options.namespace, options.connectionId)})`,
+			)
+			console.log("Tool calls will route here. Press Ctrl-C to stop.")
+			return
+		}
+
+		console.log(`Pairing uplink ... reconnected (${attempt}/${MAX_RETRIES})`)
+	}
+
+	try {
+		await local.start()
+		await connect(0)
+		return await done.promise
+	} catch (error) {
+		await stop(1)
+		throw error
+	}
+}
+
+async function pairUplinkSocket(options: {
+	baseURL: string
+	apiKey: string
+	namespace: string
+	connectionId: string
+	force?: boolean
+}): Promise<WebSocket> {
+	const preflight = await preflightUplinkPair(options)
+	if (preflight === "paired" && !options.force) {
+		throw new Error("Uplink already paired. Use --force to take over.")
+	}
+
+	const url = buildPairUrl(
+		options.baseURL,
+		options.namespace,
+		options.connectionId,
+		options.force,
+	)
+
+	return new Promise<WebSocket>((resolve, reject) => {
+		const socket = new WebSocket(url, {
+			headers: {
+				Authorization: `Bearer ${options.apiKey}`,
+			},
+		} as unknown as ConstructorParameters<typeof WebSocket>[1])
+
+		const cleanup = () => {
+			socket.removeEventListener("open", onOpen)
+			socket.removeEventListener("error", onError)
+			socket.removeEventListener("close", onClose)
+		}
+
+		const onOpen = () => {
+			cleanup()
+			resolve(socket)
+		}
+
+		const onError = () => {
+			cleanup()
+			reject(new Error("Failed to pair uplink."))
+		}
+
+		const onClose = (event: Event) => {
+			cleanup()
+			const closeEvent = event as CloseEvent
+			reject(
+				new Error(
+					closeEvent.reason ||
+						`Failed to pair uplink (code ${closeEvent.code}).`,
+				),
+			)
+		}
+
+		socket.addEventListener("open", onOpen)
+		socket.addEventListener("error", onError)
+		socket.addEventListener("close", onClose)
+	})
+}
+
+async function preflightUplinkPair(options: {
+	baseURL: string
+	apiKey: string
+	namespace: string
+	connectionId: string
+}): Promise<"paired" | "disconnected"> {
+	const response = await fetch(
+		buildHttpPairUrl(options.baseURL, options.namespace, options.connectionId),
+		{
+			headers: {
+				Authorization: `Bearer ${options.apiKey}`,
+			},
+		},
+	)
+
+	if (response.status === 200) {
+		await response.body?.cancel()
+		return "paired"
+	}
+
+	if (response.status === 503) {
+		await response.body?.cancel()
+		return "disconnected"
+	}
+
+	throw new Error(await readPairError(response))
+}
+
+function createSocketPeer(socket: WebSocket): BridgeSocketPeer {
+	return {
+		onMessage(listener) {
+			const handler = (event: MessageEvent) => {
+				if (
+					typeof event.data === "string" ||
+					event.data instanceof ArrayBuffer
+				) {
+					listener(event.data)
+					return
+				}
+
+				if (ArrayBuffer.isView(event.data)) {
+					const bytes = new Uint8Array(
+						event.data.buffer,
+						event.data.byteOffset,
+						event.data.byteLength,
+					)
+					listener(Uint8Array.from(bytes).buffer)
+				}
+			}
+			socket.addEventListener("message", handler)
+			return () => socket.removeEventListener("message", handler)
+		},
+		onClose(listener) {
+			const handler = (event: CloseEvent) => {
+				listener({ code: event.code, reason: event.reason })
+			}
+			socket.addEventListener("close", handler)
+			return () => socket.removeEventListener("close", handler)
+		},
+		onError(listener) {
+			const handler = (event: Event) => {
+				const errorEvent = event as ErrorEvent
+				listener(errorEvent.error ?? new Error(errorEvent.message))
+			}
+			socket.addEventListener("error", handler)
+			return () => socket.removeEventListener("error", handler)
+		},
+		send(text) {
+			socket.send(text)
+		},
+	}
+}
+
+function createHttpLocalPeer(mcpUrl: string): ManagedLocalPeer {
+	const transport = new StreamableHTTPClientTransport(new URL(mcpUrl))
+	const messageListeners = new Set<(message: JSONRPCMessage) => void>()
+	const closeListeners = new Set<(code?: number) => void>()
+	const errorListeners = new Set<(error: unknown) => void>()
+
+	transport.onmessage = (message) => {
+		for (const listener of messageListeners) {
+			listener(message)
+		}
+	}
+	transport.onclose = () => {
+		for (const listener of closeListeners) {
+			listener(1)
+		}
+	}
+	transport.onerror = (error) => {
+		for (const listener of errorListeners) {
+			listener(error)
+		}
+	}
+
+	return {
+		async start() {
+			await transport.start()
+		},
+		onMessage(listener) {
+			messageListeners.add(listener)
+			return () => messageListeners.delete(listener)
+		},
+		onClose(listener) {
+			closeListeners.add(listener)
+			return () => closeListeners.delete(listener)
+		},
+		onError(listener) {
+			errorListeners.add(listener)
+			return () => errorListeners.delete(listener)
+		},
+		send(message) {
+			return transport.send(message)
+		},
+		close() {
+			return transport.close()
+		},
+	}
+}
+
+function createStdioLocalPeer(
+	command: string,
+	args: string[],
+): ManagedLocalPeer {
+	const resolved = resolveSpawnCommand(command, args)
+	const readBuffer = new ReadBuffer()
+	const messageListeners = new Set<(message: JSONRPCMessage) => void>()
+	const closeListeners = new Set<(code?: number) => void>()
+	const errorListeners = new Set<(error: unknown) => void>()
+	let child: ReturnType<typeof spawn> | null = null
+
+	return {
+		start() {
+			return new Promise<void>((resolve, reject) => {
+				child = spawn(resolved.command, resolved.args, {
+					cwd: process.cwd(),
+					env: getRuntimeEnvironment(getStringEnv(process.env)),
+					stdio: ["pipe", "pipe", "inherit"],
+					shell: false,
+				})
+
+				child.on("error", (error) => {
+					reject(error)
+					for (const listener of errorListeners) {
+						listener(error)
+					}
+				})
+
+				child.on("spawn", () => resolve())
+
+				child.on("close", (code, signal) => {
+					child = null
+					const exitCode = code ?? (signal ? 1 : 0)
+					for (const listener of closeListeners) {
+						listener(exitCode)
+					}
+				})
+
+				child.stdout?.on("data", (chunk: Buffer) => {
+					readBuffer.append(chunk)
+					while (true) {
+						try {
+							const message = readBuffer.readMessage()
+							if (message === null) {
+								break
+							}
+							for (const listener of messageListeners) {
+								listener(message)
+							}
+						} catch (error) {
+							for (const listener of errorListeners) {
+								listener(error)
+							}
+							break
+						}
+					}
+				})
+
+				child.stdout?.on("error", (error) => {
+					for (const listener of errorListeners) {
+						listener(error)
+					}
+				})
+
+				child.stdin?.on("error", (error) => {
+					for (const listener of errorListeners) {
+						listener(error)
+					}
+				})
+			})
+		},
+		onMessage(listener) {
+			messageListeners.add(listener)
+			return () => messageListeners.delete(listener)
+		},
+		onClose(listener) {
+			closeListeners.add(listener)
+			return () => closeListeners.delete(listener)
+		},
+		onError(listener) {
+			errorListeners.add(listener)
+			return () => errorListeners.delete(listener)
+		},
+		send(message) {
+			return writeToChild(child, serializeMessage(message))
+		},
+		async close() {
+			if (!child) {
+				return
+			}
+
+			const processToClose = child
+			child = null
+			const closePromise = waitForProcessExit(processToClose)
+
+			try {
+				processToClose.stdin?.end()
+			} catch {
+				// Ignore stdin close failures.
+			}
+
+			await Promise.race([closePromise, delay(STDIO_KILL_TIMEOUT_MS)])
+			if (processToClose.exitCode === null) {
+				processToClose.kill("SIGTERM")
+			}
+
+			await Promise.race([closePromise, delay(STDIO_KILL_TIMEOUT_MS)])
+			if (processToClose.exitCode === null) {
+				processToClose.kill("SIGKILL")
+			}
+		},
+	}
+}
+
+function buildPairUrl(
+	baseURL: string,
+	namespace: string,
+	connectionId: string,
+	force = false,
+): string {
+	const url = new URL(
+		`/connect/${encodeURIComponent(namespace)}/${encodeURIComponent(connectionId)}/uplink`,
+		baseURL,
+	)
+	if (force) {
+		url.searchParams.set("force", "1")
+	}
+	url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
+	return url.toString()
+}
+
+function buildHttpPairUrl(
+	baseURL: string,
+	namespace: string,
+	connectionId: string,
+): string {
+	return new URL(
+		`/connect/${encodeURIComponent(namespace)}/${encodeURIComponent(connectionId)}/uplink`,
+		baseURL,
+	).toString()
+}
+
+async function readPairError(response: Response): Promise<string> {
+	const text = await response.text().catch(() => "")
+	try {
+		const parsed = JSON.parse(text) as { message?: string }
+		if (parsed.message) {
+			return parsed.message
+		}
+	} catch {
+		// Ignore JSON parse errors and fall back to plain text.
+	}
+
+	if (response.status === 401) {
+		return "Authentication failed. Run 'smithery login' to re-authenticate."
+	}
+
+	if (response.status === 403) {
+		return "Permission denied. Your token needs connections:write on this namespace."
+	}
+
+	if (response.status === 404) {
+		return "Connection not found."
+	}
+
+	return text || `Request failed with status ${response.status}.`
+}
+
+function describeLocalTarget(target: UplinkTarget): string {
+	if (target.kind === "uplink-http") {
+		return target.mcpUrl
+	}
+	return formatShellCommand(target.command, target.args)
+}
+
+function getConnectionUrl(namespace: string, connectionId: string): string {
+	return `https://smithery.ai/connect/${encodeURIComponent(namespace)}/${encodeURIComponent(connectionId)}`
+}
+
+function resolveSpawnCommand(
+	command: string,
+	args: string[],
+): { command: string; args: string[] } {
+	if (process.platform === "win32" && command === "npx") {
+		return {
+			command: "cmd",
+			args: ["/c", "npx", ...args],
+		}
+	}
+
+	return { command, args }
+}
+
+function getStringEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(env).filter((entry): entry is [string, string] => {
+			return typeof entry[1] === "string"
+		}),
+	)
+}
+
+async function writeToChild(
+	child: ReturnType<typeof spawn> | null,
+	payload: string,
+): Promise<void> {
+	if (!child?.stdin) {
+		throw new Error("Local MCP process is not running.")
+	}
+
+	await new Promise<void>((resolve, reject) => {
+		child.stdin?.once("error", reject)
+		if (child.stdin?.write(payload)) {
+			child.stdin?.removeListener("error", reject)
+			resolve()
+			return
+		}
+		child.stdin?.once("drain", () => {
+			child.stdin?.removeListener("error", reject)
+			resolve()
+		})
+	})
+}
+
+function waitForProcessExit(child: ReturnType<typeof spawn>): Promise<void> {
+	return new Promise((resolve) => {
+		child.once("close", () => resolve())
+	})
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(resolve, ms)
+		timer.unref?.()
+	})
+}
+
+function formatShellCommand(command: string, args: string[]): string {
+	return [command, ...args]
+		.map((part) => {
+			if (/^[A-Za-z0-9_./:@=-]+$/.test(part)) {
+				return part
+			}
+			return JSON.stringify(part)
+		})
+		.join(" ")
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
+}


### PR DESCRIPTION
## What changed

This teaches `smithery mcp add` how to create and pair uplink-backed connections for local MCP servers.

- detects loopback HTTP targets and trailing `-- <command...>` invocations as uplink flows
- creates uplink connections with `transport: "uplink"` and adds a foreground websocket bridge for HTTP and stdio local MCP servers
- rejects unsupported uplink flags before the API call and reuses `--force` for takeover pairing
- updates connection formatting and add-flow handling for nullable `mcpUrl`, uplink transport, and `disconnected` status
- adds unit coverage for target detection, connection CRUD payloads, and websocket bridge behavior
- temporarily pins `@smithery/api` to the latest Stainless tarball while generated types catch up

## Why

The backend now supports uplink-backed Connect connections, but the CLI only had partial transport typing and no pairing runtime. This closes that gap so local MCP servers can be exposed through the normal Smithery connection surface with a single `smithery mcp add` command.

## Impact

Loopback URLs like `http://localhost:9090/mcp` and local commands passed after `--` now register uplink connections and keep the CLI running in the foreground as the bridge. Existing non-local HTTP add flows remain unchanged.

## Validation

- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm test`
