### PR TITLE
feat(SMI-1823): add trigger CLI commands

### DIFF
--- a/src/commands/__tests__/trigger-api.test.ts
+++ b/src/commands/__tests__/trigger-api.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi } from "vitest"
+import { ConnectSession } from "../mcp/api"
+
+describe("ConnectSession trigger support", () => {
+	test("uses trigger endpoints for trigger types and instances", async () => {
+		const get = vi
+			.fn()
+			.mockResolvedValueOnce({ triggers: [] })
+			.mockResolvedValueOnce({ name: "page.updated" })
+			.mockResolvedValueOnce({ id: "trg_123" })
+		const post = vi
+			.fn()
+			.mockResolvedValueOnce({ id: "trg_123" })
+			.mockResolvedValueOnce({ id: "sub_123" })
+			.mockResolvedValueOnce({ id: "sub_456" })
+		const del = vi.fn().mockResolvedValue({ success: true })
+
+		const session = new ConnectSession(
+			{ get, post, delete: del } as never,
+			"my app",
+		)
+
+		await session.listTriggers("notion")
+		await session.getTrigger("notion", "page.updated")
+		await session.createTrigger("notion", "page.updated", {
+			workspace_id: "w_123",
+		})
+		await session.getTriggerInstance("notion", "page.updated", "trg_123")
+		await session.deleteTrigger("notion", "page.updated", "trg_123")
+		await session.listSubscriptions()
+		await session.createSubscription("https://example.com/events")
+		await session.listSubscriptions("notion")
+		await session.createSubscription("https://example.com/notion", "notion")
+		await session.deleteSubscription("sub_123")
+		await session.deleteSubscription("sub_456", "notion")
+
+		expect(get).toHaveBeenNthCalledWith(1, "/my%20app/notion/triggers")
+		expect(get).toHaveBeenNthCalledWith(
+			2,
+			"/my%20app/notion/triggers/page.updated",
+		)
+		expect(post).toHaveBeenNthCalledWith(
+			1,
+			"/my%20app/notion/triggers/page.updated",
+			{
+				body: { params: { workspace_id: "w_123" } },
+			},
+		)
+		expect(get).toHaveBeenNthCalledWith(
+			3,
+			"/my%20app/notion/triggers/page.updated/trg_123",
+		)
+		expect(del).toHaveBeenNthCalledWith(
+			1,
+			"/my%20app/notion/triggers/page.updated/trg_123",
+		)
+		expect(get).toHaveBeenNthCalledWith(4, "/my%20app/subscriptions")
+		expect(post).toHaveBeenNthCalledWith(2, "/my%20app/subscriptions", {
+			body: { url: "https://example.com/events" },
+		})
+		expect(get).toHaveBeenNthCalledWith(5, "/my%20app/notion/subscriptions")
+		expect(post).toHaveBeenNthCalledWith(3, "/my%20app/notion/subscriptions", {
+			body: { url: "https://example.com/notion" },
+		})
+		expect(del).toHaveBeenNthCalledWith(2, "/my%20app/subscriptions/sub_123")
+		expect(del).toHaveBeenNthCalledWith(
+			3,
+			"/my%20app/notion/subscriptions/sub_456",
+		)
+	})
+})

--- a/src/commands/__tests__/trigger-api.test.ts
+++ b/src/commands/__tests__/trigger-api.test.ts
@@ -68,4 +68,23 @@ describe("ConnectSession trigger support", () => {
 			"/my%20app/notion/subscriptions/sub_456",
 		)
 	})
+
+	test("lists trigger types through the MCP events extension", async () => {
+		const request = vi.fn().mockResolvedValue({
+			events: [{ name: "page.updated" }],
+		})
+		const close = vi.fn().mockResolvedValue(undefined)
+		const session = new ConnectSession({} as never, "calclavia")
+		session.getEventsClient = vi.fn().mockResolvedValue({ request, close })
+
+		const result = await session.listEventTriggers("notion")
+
+		expect(session.getEventsClient).toHaveBeenCalledWith("notion")
+		expect(request).toHaveBeenCalledWith(
+			{ method: "ai.smithery/events/list" },
+			expect.anything(),
+		)
+		expect(result).toEqual([{ name: "page.updated" }])
+		expect(close).toHaveBeenCalled()
+	})
 })

--- a/src/commands/__tests__/trigger.test.ts
+++ b/src/commands/__tests__/trigger.test.ts
@@ -75,6 +75,21 @@ describe("trigger commands", () => {
 		setOutputMode({ json: true })
 	})
 
+	test("prints a draft warning before trigger commands", async () => {
+		mockListEventTriggers.mockResolvedValue([])
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+		await listTriggers("notion", {})
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Triggers are in draft. Breaking change may happen without notice.",
+			),
+		)
+
+		warnSpy.mockRestore()
+	})
+
 	test("lists trigger types for a connection", async () => {
 		mockListEventTriggers.mockResolvedValue([
 			{

--- a/src/commands/__tests__/trigger.test.ts
+++ b/src/commands/__tests__/trigger.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+	mockListTriggers,
+	mockCreateTrigger,
+	mockListSubscriptions,
+	mockCreateSubscription,
+	mockCreateSession,
+	mockOutputTable,
+	mockOutputDetail,
+} = vi.hoisted(() => {
+	const listTriggers = vi.fn()
+	const createTrigger = vi.fn()
+	const listSubscriptions = vi.fn()
+	const createSubscription = vi.fn()
+	const createSession = vi.fn(async () => ({
+		listTriggers,
+		createTrigger,
+		listSubscriptions,
+		createSubscription,
+	}))
+
+	return {
+		mockListTriggers: listTriggers,
+		mockCreateTrigger: createTrigger,
+		mockListSubscriptions: listSubscriptions,
+		mockCreateSubscription: createSubscription,
+		mockCreateSession: createSession,
+		mockOutputTable: vi.fn(),
+		mockOutputDetail: vi.fn(),
+	}
+})
+
+vi.mock("../mcp/api", () => ({
+	ConnectSession: {
+		create: mockCreateSession,
+	},
+}))
+
+vi.mock("../../utils/output", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../utils/output")>()
+	return {
+		...actual,
+		outputTable: mockOutputTable,
+		outputDetail: mockOutputDetail,
+	}
+})
+
+import { setOutputMode } from "../../utils/output"
+import {
+	createSubscription,
+	listSubscriptions,
+	listTriggers,
+	subscribeTrigger,
+} from "../trigger"
+
+let program: typeof import("../../index").program
+const testGlobal = globalThis as typeof globalThis & {
+	__SMITHERY_VERSION__: string
+}
+
+beforeAll(async () => {
+	testGlobal.__SMITHERY_VERSION__ = "test"
+	;({ program } = await import("../../index"))
+})
+
+describe("trigger commands", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		setOutputMode({ json: true })
+	})
+
+	test("lists trigger types for a connection", async () => {
+		mockListTriggers.mockResolvedValue([
+			{
+				name: "page.updated",
+				description: "Fires when a page changes.",
+				delivery: ["webhook"],
+				inputSchema: { type: "object" },
+			},
+		])
+
+		await listTriggers("notion", { namespace: "prod" })
+
+		expect(mockCreateSession).toHaveBeenCalledWith("prod")
+		expect(mockListTriggers).toHaveBeenCalledWith("notion")
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					triggers: [
+						expect.objectContaining({
+							name: "page.updated",
+						}),
+					],
+				}),
+			}),
+		)
+	})
+
+	test("creates a trigger instance from JSON params", async () => {
+		mockCreateTrigger.mockResolvedValue({
+			id: "trg_123",
+			name: "page.updated",
+			connection_id: "notion",
+			params: { workspace_id: "w_123" },
+			created_at: "2026-04-22T12:00:00.000Z",
+		})
+
+		await subscribeTrigger(
+			"notion",
+			"page.updated",
+			'{"workspace_id":"w_123"}',
+			{},
+		)
+
+		expect(mockCreateTrigger).toHaveBeenCalledWith("notion", "page.updated", {
+			workspace_id: "w_123",
+		})
+		expect(mockOutputDetail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					id: "trg_123",
+					connection: "notion",
+				}),
+			}),
+		)
+	})
+
+	test("lists connection-scoped subscriptions", async () => {
+		mockListSubscriptions.mockResolvedValue([
+			{ id: "sub_123", url: "https://example.com/events" },
+		])
+
+		await listSubscriptions("notion", {})
+
+		expect(mockListSubscriptions).toHaveBeenCalledWith("notion")
+		expect(mockOutputTable).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jsonData: expect.objectContaining({
+					subscriptions: [{ id: "sub_123", url: "https://example.com/events" }],
+				}),
+			}),
+		)
+	})
+
+	test("creates namespace-scoped subscriptions when no connection is passed", async () => {
+		mockCreateSubscription.mockResolvedValue({
+			id: "sub_123",
+			url: "https://example.com/events",
+			secret: "whsec_123",
+		})
+
+		await createSubscription("https://example.com/events", undefined, {})
+
+		expect(mockCreateSession).toHaveBeenCalledWith(undefined)
+		expect(mockCreateSubscription).toHaveBeenCalledWith(
+			"https://example.com/events",
+			undefined,
+		)
+	})
+
+	test("registers trigger and subscription commands", () => {
+		const triggerCmd = program.commands.find(
+			(command) => command.name() === "trigger",
+		)
+		const subCmd = triggerCmd?.commands.find(
+			(command) => command.name() === "subscription",
+		)
+
+		expect(triggerCmd).toBeDefined()
+		expect(
+			triggerCmd?.commands.map((command) => command.name()).sort(),
+		).toEqual(["get", "list", "subscribe", "subscription", "unsubscribe"])
+		expect(subCmd?.commands.map((command) => command.name()).sort()).toEqual([
+			"add",
+			"list",
+			"remove",
+		])
+	})
+})

--- a/src/commands/__tests__/trigger.test.ts
+++ b/src/commands/__tests__/trigger.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
-	mockListTriggers,
+	mockListEventTriggers,
 	mockCreateTrigger,
 	mockListSubscriptions,
 	mockCreateSubscription,
@@ -9,19 +9,19 @@ const {
 	mockOutputTable,
 	mockOutputDetail,
 } = vi.hoisted(() => {
-	const listTriggers = vi.fn()
+	const listEventTriggers = vi.fn()
 	const createTrigger = vi.fn()
 	const listSubscriptions = vi.fn()
 	const createSubscription = vi.fn()
 	const createSession = vi.fn(async () => ({
-		listTriggers,
+		listEventTriggers,
 		createTrigger,
 		listSubscriptions,
 		createSubscription,
 	}))
 
 	return {
-		mockListTriggers: listTriggers,
+		mockListEventTriggers: listEventTriggers,
 		mockCreateTrigger: createTrigger,
 		mockListSubscriptions: listSubscriptions,
 		mockCreateSubscription: createSubscription,
@@ -71,7 +71,7 @@ describe("trigger commands", () => {
 	})
 
 	test("lists trigger types for a connection", async () => {
-		mockListTriggers.mockResolvedValue([
+		mockListEventTriggers.mockResolvedValue([
 			{
 				name: "page.updated",
 				description: "Fires when a page changes.",
@@ -83,7 +83,7 @@ describe("trigger commands", () => {
 		await listTriggers("notion", { namespace: "prod" })
 
 		expect(mockCreateSession).toHaveBeenCalledWith("prod")
-		expect(mockListTriggers).toHaveBeenCalledWith("notion")
+		expect(mockListEventTriggers).toHaveBeenCalledWith("notion")
 		expect(mockOutputTable).toHaveBeenCalledWith(
 			expect.objectContaining({
 				jsonData: expect.objectContaining({
@@ -92,6 +92,31 @@ describe("trigger commands", () => {
 							name: "page.updated",
 						}),
 					],
+				}),
+			}),
+		)
+	})
+
+	test("gets trigger schemas from the MCP trigger catalog", async () => {
+		mockListEventTriggers.mockResolvedValue([
+			{
+				name: "page.updated",
+				description: "Fires when a page changes.",
+				delivery: ["webhook"],
+				inputSchema: { type: "object" },
+				payloadSchema: { type: "object" },
+			},
+		])
+
+		const { getTrigger } = await import("../trigger")
+		await getTrigger("notion", "page.updated", undefined, {})
+
+		expect(mockListEventTriggers).toHaveBeenCalledWith("notion")
+		expect(mockOutputDetail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					name: "page.updated",
+					inputSchema: { type: "object" },
 				}),
 			}),
 		)

--- a/src/commands/__tests__/trigger.test.ts
+++ b/src/commands/__tests__/trigger.test.ts
@@ -2,7 +2,6 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
 	mockListEventTriggers,
-	mockCreateTrigger,
 	mockListSubscriptions,
 	mockCreateSubscription,
 	mockCreateSession,
@@ -12,7 +11,6 @@ const {
 	mockOutputJson,
 } = vi.hoisted(() => {
 	const listEventTriggers = vi.fn()
-	const createTrigger = vi.fn()
 	const listSubscriptions = vi.fn()
 	const createSubscription = vi.fn()
 	const request = vi.fn()
@@ -20,7 +18,6 @@ const {
 	const getEventsClient = vi.fn(async () => ({ request, close }))
 	const createSession = vi.fn(async () => ({
 		listEventTriggers,
-		createTrigger,
 		listSubscriptions,
 		createSubscription,
 		getEventsClient,
@@ -28,7 +25,6 @@ const {
 
 	return {
 		mockListEventTriggers: listEventTriggers,
-		mockCreateTrigger: createTrigger,
 		mockListSubscriptions: listSubscriptions,
 		mockCreateSubscription: createSubscription,
 		mockCreateSession: createSession,
@@ -80,7 +76,7 @@ describe("trigger commands", () => {
 	})
 
 	test("lists trigger types for a connection", async () => {
-	mockListEventTriggers.mockResolvedValue([
+		mockListEventTriggers.mockResolvedValue([
 			{
 				name: "page.updated",
 				description: "Fires when a page changes.",

--- a/src/commands/__tests__/trigger.test.ts
+++ b/src/commands/__tests__/trigger.test.ts
@@ -6,18 +6,24 @@ const {
 	mockListSubscriptions,
 	mockCreateSubscription,
 	mockCreateSession,
+	mockGetEventsClient,
 	mockOutputTable,
 	mockOutputDetail,
+	mockOutputJson,
 } = vi.hoisted(() => {
 	const listEventTriggers = vi.fn()
 	const createTrigger = vi.fn()
 	const listSubscriptions = vi.fn()
 	const createSubscription = vi.fn()
+	const request = vi.fn()
+	const close = vi.fn().mockResolvedValue(undefined)
+	const getEventsClient = vi.fn(async () => ({ request, close }))
 	const createSession = vi.fn(async () => ({
 		listEventTriggers,
 		createTrigger,
 		listSubscriptions,
 		createSubscription,
+		getEventsClient,
 	}))
 
 	return {
@@ -26,8 +32,10 @@ const {
 		mockListSubscriptions: listSubscriptions,
 		mockCreateSubscription: createSubscription,
 		mockCreateSession: createSession,
+		mockGetEventsClient: getEventsClient,
 		mockOutputTable: vi.fn(),
 		mockOutputDetail: vi.fn(),
+		mockOutputJson: vi.fn(),
 	}
 })
 
@@ -43,6 +51,7 @@ vi.mock("../../utils/output", async (importOriginal) => {
 		...actual,
 		outputTable: mockOutputTable,
 		outputDetail: mockOutputDetail,
+		outputJson: mockOutputJson,
 	}
 })
 
@@ -71,7 +80,7 @@ describe("trigger commands", () => {
 	})
 
 	test("lists trigger types for a connection", async () => {
-		mockListEventTriggers.mockResolvedValue([
+	mockListEventTriggers.mockResolvedValue([
 			{
 				name: "page.updated",
 				description: "Fires when a page changes.",
@@ -123,32 +132,67 @@ describe("trigger commands", () => {
 	})
 
 	test("creates a trigger instance from JSON params", async () => {
-		mockCreateTrigger.mockResolvedValue({
-			id: "trg_123",
-			name: "page.updated",
-			connection_id: "notion",
-			params: { workspace_id: "w_123" },
-			created_at: "2026-04-22T12:00:00.000Z",
-		})
+		const request = vi.fn().mockResolvedValue({ subscriptionId: "trg_123" })
+		const close = vi.fn().mockResolvedValue(undefined)
+		mockGetEventsClient.mockResolvedValue({ request, close })
 
 		await subscribeTrigger(
 			"notion",
 			"page.updated",
 			'{"workspace_id":"w_123"}',
-			{},
+			{ url: "https://hook.new/i/test" },
 		)
 
-		expect(mockCreateTrigger).toHaveBeenCalledWith("notion", "page.updated", {
-			workspace_id: "w_123",
-		})
+		expect(request).toHaveBeenCalledWith(
+			{
+				method: "ai.smithery/events/subscribe",
+				params: {
+					name: "page.updated",
+					id: expect.any(String),
+					params: { workspace_id: "w_123" },
+					delivery: {
+						mode: "webhook",
+						url: "https://hook.new/i/test",
+					},
+				},
+			},
+			expect.anything(),
+		)
 		expect(mockOutputDetail).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
-					id: "trg_123",
+					subscriptionId: "trg_123",
 					connection: "notion",
+					name: "page.updated",
+					url: "https://hook.new/i/test",
 				}),
 			}),
 		)
+		expect(close).toHaveBeenCalled()
+	})
+
+	test("requires a delivery URL when creating a trigger instance", async () => {
+		await expect(
+			subscribeTrigger("notion", "page.updated", undefined, {}),
+		).rejects.toThrow("process.exit")
+	})
+
+	test("unsubscribes through the MCP events extension", async () => {
+		const request = vi.fn().mockResolvedValue({})
+		const close = vi.fn().mockResolvedValue(undefined)
+		mockGetEventsClient.mockResolvedValue({ request, close })
+
+		const { unsubscribeTrigger } = await import("../trigger")
+		await unsubscribeTrigger("notion", "page.updated", undefined, {})
+
+		expect(request).toHaveBeenCalledWith(
+			{
+				method: "ai.smithery/events/unsubscribe",
+				params: { topic: "page.updated" },
+			},
+			expect.anything(),
+		)
+		expect(close).toHaveBeenCalled()
 	})
 
 	test("lists connection-scoped subscriptions", async () => {

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -5,6 +5,7 @@ import {
 	type CreateConnectionOptions,
 	createConnection as createSmitheryConnection,
 } from "@smithery/api/mcp"
+import { listEventTriggers } from "../../lib/events"
 import type {
 	Connection,
 	ConnectionCreateParams,
@@ -187,6 +188,16 @@ export class ConnectSession {
 		)
 		await mcpClient.connect(transport)
 		return mcpClient
+	}
+
+	async listEventTriggers(connectionId: string): Promise<Trigger[]> {
+		const mcpClient = await this.getEventsClient(connectionId)
+		try {
+			const { events } = await listEventTriggers(mcpClient)
+			return events
+		} finally {
+			await mcpClient.close()
+		}
 	}
 
 	async callTool(

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -20,6 +20,28 @@ import {
 export type { Connection, ConnectionsListResponse }
 export type ConnectionTransport = NonNullable<Connection["transport"]>
 
+export interface Trigger {
+	name: string
+	description?: string
+	delivery?: string[]
+	inputSchema?: Record<string, unknown>
+	payloadSchema?: Record<string, unknown>
+}
+
+export interface TriggerInstance {
+	id: string
+	name: string
+	connection_id?: string
+	params?: Record<string, unknown>
+	created_at?: string
+}
+
+export interface TriggerSubscription {
+	id: string
+	url: string
+	secret?: string
+}
+
 export interface ToolInfo extends Tool {
 	connectionId: string
 	connectionName: string
@@ -233,6 +255,85 @@ export class ConnectSession {
 		)
 	}
 
+	async listTriggers(connectionId: string): Promise<Trigger[]> {
+		const response = await this.smitheryClient.get<{ triggers?: Trigger[] }>(
+			triggerCollectionPath(this.namespace, connectionId),
+		)
+		return response?.triggers ?? []
+	}
+
+	async getTrigger(
+		connectionId: string,
+		triggerName: string,
+	): Promise<Trigger> {
+		return this.smitheryClient.get<Trigger>(
+			triggerItemPath(this.namespace, connectionId, triggerName),
+		)
+	}
+
+	async createTrigger(
+		connectionId: string,
+		triggerName: string,
+		params: Record<string, unknown> = {},
+	): Promise<TriggerInstance> {
+		return this.smitheryClient.post<TriggerInstance>(
+			triggerItemPath(this.namespace, connectionId, triggerName),
+			{
+				body: { params },
+			},
+		)
+	}
+
+	async getTriggerInstance(
+		connectionId: string,
+		triggerName: string,
+		triggerId: string,
+	): Promise<TriggerInstance> {
+		return this.smitheryClient.get<TriggerInstance>(
+			triggerInstancePath(this.namespace, connectionId, triggerName, triggerId),
+		)
+	}
+
+	async deleteTrigger(
+		connectionId: string,
+		triggerName: string,
+		triggerId: string,
+	): Promise<void> {
+		await this.smitheryClient.delete(
+			triggerInstancePath(this.namespace, connectionId, triggerName, triggerId),
+		)
+	}
+
+	async listSubscriptions(
+		connectionId?: string,
+	): Promise<TriggerSubscription[]> {
+		const response = await this.smitheryClient.get<{
+			subscriptions?: TriggerSubscription[]
+		}>(subscriptionCollectionPath(this.namespace, connectionId))
+		return response?.subscriptions ?? []
+	}
+
+	async createSubscription(
+		url: string,
+		connectionId?: string,
+	): Promise<TriggerSubscription> {
+		return this.smitheryClient.post<TriggerSubscription>(
+			subscriptionCollectionPath(this.namespace, connectionId),
+			{
+				body: { url },
+			},
+		)
+	}
+
+	async deleteSubscription(
+		subscriptionId: string,
+		connectionId?: string,
+	): Promise<void> {
+		await this.smitheryClient.delete(
+			subscriptionItemPath(this.namespace, subscriptionId, connectionId),
+		)
+	}
+
 	async pollEvents(connectionId: string, options?: { limit?: number }) {
 		return this.smitheryClient.get<{
 			data: Array<{
@@ -277,6 +378,52 @@ function connectCollectionPath(namespace: string): string {
 
 function connectItemPath(namespace: string, connectionId: string): string {
 	return `${connectCollectionPath(namespace)}/${encodeURIComponent(connectionId)}`
+}
+
+function namespacePath(namespace: string): string {
+	return `/${encodeURIComponent(namespace)}`
+}
+
+function triggerCollectionPath(
+	namespace: string,
+	connectionId: string,
+): string {
+	return `${namespacePath(namespace)}/${encodeURIComponent(connectionId)}/triggers`
+}
+
+function triggerItemPath(
+	namespace: string,
+	connectionId: string,
+	triggerName: string,
+): string {
+	return `${triggerCollectionPath(namespace, connectionId)}/${encodeURIComponent(triggerName)}`
+}
+
+function triggerInstancePath(
+	namespace: string,
+	connectionId: string,
+	triggerName: string,
+	triggerId: string,
+): string {
+	return `${triggerItemPath(namespace, connectionId, triggerName)}/${encodeURIComponent(triggerId)}`
+}
+
+function subscriptionCollectionPath(
+	namespace: string,
+	connectionId?: string,
+): string {
+	if (!connectionId) {
+		return `${namespacePath(namespace)}/subscriptions`
+	}
+	return `${namespacePath(namespace)}/${encodeURIComponent(connectionId)}/subscriptions`
+}
+
+function subscriptionItemPath(
+	namespace: string,
+	subscriptionId: string,
+	connectionId?: string,
+): string {
+	return `${subscriptionCollectionPath(namespace, connectionId)}/${encodeURIComponent(subscriptionId)}`
 }
 
 function toMetadataQuery(

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -5,13 +5,13 @@ import {
 	type CreateConnectionOptions,
 	createConnection as createSmitheryConnection,
 } from "@smithery/api/mcp"
-import { listEventTriggers } from "../../lib/events"
 import type {
 	Connection,
 	ConnectionCreateParams,
 	ConnectionListParams,
 	ConnectionsListResponse,
 } from "@smithery/api/resources/connections/connections.js"
+import { listEventTriggers } from "../../lib/events"
 import { createSmitheryClient } from "../../lib/smithery-client"
 import {
 	getNamespace as getStoredNamespace,

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -1,5 +1,6 @@
 import pc from "picocolors"
-import { fatal } from "../lib/cli-error"
+import { errorMessage, fatal, handleMCPAuthError } from "../lib/cli-error"
+import { EmptyEventResultSchema } from "../lib/events"
 import {
 	isJsonMode,
 	outputDetail,
@@ -91,49 +92,120 @@ export async function subscribeTrigger(
 	connection: string,
 	name: string,
 	paramsJson: string | undefined,
-	options: { namespace?: string },
+	options: { namespace?: string; url?: string; id?: string },
 ): Promise<void> {
+	const isJson = isJsonMode()
+
 	try {
+		if (!options.url) {
+			fatal("Trigger delivery URL is required. Pass --url <webhook-url>.")
+		}
+
 		const params =
 			parseJsonObject<Record<string, unknown>>(paramsJson, "Params") ?? {}
 		const session = await ConnectSession.create(options.namespace)
-		const trigger = await session.createTrigger(connection, name, params)
+		const mcpClient = await session.getEventsClient(connection)
+		try {
+			const trigger = await mcpClient.request(
+				{
+					method: "ai.smithery/events/subscribe",
+					params: {
+						name,
+						id: options.id ?? crypto.randomUUID(),
+						params,
+						delivery: {
+							mode: "webhook",
+							url: options.url,
+						},
+					},
+				},
+				EmptyEventResultSchema,
+			)
 
-		outputDetail({
-			data: {
-				id: trigger.id,
-				connection,
-				name: trigger.name,
-				params: trigger.params,
-				createdAt: trigger.created_at,
-			},
-			tip: `Use smithery trigger unsubscribe ${connection} ${name} ${trigger.id} to delete this trigger.`,
-		})
+			if (
+				trigger &&
+				typeof trigger === "object" &&
+				Object.keys(trigger as Record<string, unknown>).length > 0
+			) {
+				outputDetail({
+					data: {
+						connection,
+						name,
+						url: options.url,
+						...trigger,
+					},
+					tip: `Use smithery trigger unsubscribe ${connection} ${name} to delete this trigger.`,
+				})
+				return
+			}
+
+			if (isJson) {
+				outputJson({
+					connection,
+					name,
+					url: options.url,
+					subscribed: true,
+				})
+			} else {
+				console.log(
+					pc.green(`Subscribed to ${pc.bold(name)} on ${connection}.`),
+				)
+			}
+		} finally {
+			await mcpClient.close()
+		}
 	} catch (error) {
-		fatal("Failed to subscribe to trigger", error)
+		handleMCPAuthError(error, connection, { json: isJson })
+		const msg = errorMessage(error)
+		if (isJson) {
+			outputJson({ error: `Failed to subscribe to trigger: ${msg}` })
+		} else {
+			console.error(pc.red(`Failed to subscribe to trigger: ${msg}`))
+		}
+		process.exit(1)
 	}
 }
 
 export async function unsubscribeTrigger(
 	connection: string,
 	name: string,
-	id: string,
+	id: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	const isJson = isJsonMode()
+
 	try {
 		const session = await ConnectSession.create(options.namespace)
-		await session.deleteTrigger(connection, name, id)
+		const mcpClient = await session.getEventsClient(connection)
+		try {
+			await mcpClient.request(
+				{
+					method: "ai.smithery/events/unsubscribe",
+					params: { topic: name },
+				},
+				EmptyEventResultSchema,
+			)
+		} finally {
+			await mcpClient.close()
+		}
 
-		if (isJsonMode()) {
-			outputJson({ removed: [{ connection, name, id }] })
+		if (isJson) {
+			outputJson({
+				removed: [{ connection, name, ...(id ? { id } : {}) }],
+			})
 			return
 		}
 
-		console.log(
-			`${pc.green("✓")} Removed trigger ${name} (${id}) from ${connection}`,
-		)
+		console.log(`${pc.green("✓")} Removed trigger ${name} from ${connection}`)
 	} catch (error) {
-		fatal("Failed to unsubscribe trigger", error)
+		handleMCPAuthError(error, connection, { json: isJson })
+		const msg = errorMessage(error)
+		if (isJson) {
+			outputJson({ error: `Failed to unsubscribe trigger: ${msg}` })
+		} else {
+			console.error(pc.red(`Failed to unsubscribe trigger: ${msg}`))
+		}
+		process.exit(1)
 	}
 }
 

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -15,7 +15,7 @@ export async function listTriggers(
 ): Promise<void> {
 	try {
 		const session = await ConnectSession.create(options.namespace)
-		const triggers = await session.listTriggers(connection)
+		const triggers = await session.listEventTriggers(connection)
 		const data = triggers.map((trigger) => ({
 			name: trigger.name,
 			delivery: (trigger.delivery ?? []).join(","),
@@ -66,7 +66,11 @@ export async function getTrigger(
 			return
 		}
 
-		const trigger = await session.getTrigger(connection, name)
+		const triggers = await session.listEventTriggers(connection)
+		const trigger = triggers.find((event) => event.name === name)
+		if (!trigger) {
+			fatal(`Trigger "${name}" was not found on connection "${connection}".`)
+		}
 		outputDetail({
 			data: {
 				connection,

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -10,10 +10,17 @@ import {
 import { ConnectSession } from "./mcp/api"
 import { parseJsonObject } from "./mcp/parse-json"
 
+function warnPreview(): void {
+	console.warn(
+		pc.yellow("Triggers are in draft. Breaking change may happen without notice."),
+	)
+}
+
 export async function listTriggers(
 	connection: string,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	try {
 		const session = await ConnectSession.create(options.namespace)
 		const triggers = await session.listEventTriggers(connection)
@@ -50,6 +57,7 @@ export async function getTrigger(
 	id: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	try {
 		const session = await ConnectSession.create(options.namespace)
 		if (id) {
@@ -94,6 +102,7 @@ export async function subscribeTrigger(
 	paramsJson: string | undefined,
 	options: { namespace?: string; url?: string; id?: string },
 ): Promise<void> {
+	warnPreview()
 	const isJson = isJsonMode()
 
 	try {
@@ -172,6 +181,7 @@ export async function unsubscribeTrigger(
 	id: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	const isJson = isJsonMode()
 
 	try {
@@ -213,6 +223,7 @@ export async function listSubscriptions(
 	connection: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	try {
 		const session = await ConnectSession.create(options.namespace)
 		const subscriptions = await session.listSubscriptions(connection)
@@ -248,6 +259,7 @@ export async function createSubscription(
 	connection: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	try {
 		const session = await ConnectSession.create(options.namespace)
 		const subscription = await session.createSubscription(url, connection)
@@ -272,6 +284,7 @@ export async function removeSubscription(
 	connection: string | undefined,
 	options: { namespace?: string },
 ): Promise<void> {
+	warnPreview()
 	try {
 		const session = await ConnectSession.create(options.namespace)
 		await session.deleteSubscription(id, connection)

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -1,0 +1,220 @@
+import pc from "picocolors"
+import { fatal } from "../lib/cli-error"
+import {
+	isJsonMode,
+	outputDetail,
+	outputJson,
+	outputTable,
+} from "../utils/output"
+import { ConnectSession } from "./mcp/api"
+import { parseJsonObject } from "./mcp/parse-json"
+
+export async function listTriggers(
+	connection: string,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		const triggers = await session.listTriggers(connection)
+		const data = triggers.map((trigger) => ({
+			name: trigger.name,
+			delivery: (trigger.delivery ?? []).join(","),
+			description: trigger.description ?? "",
+			params: trigger.inputSchema ? "yes" : "no",
+		}))
+
+		outputTable({
+			data,
+			columns: [
+				{ key: "name", header: "TRIGGER" },
+				{ key: "delivery", header: "DELIVERY" },
+				{ key: "params", header: "PARAMS" },
+				{ key: "description", header: "DESCRIPTION" },
+			],
+			json: isJsonMode(),
+			jsonData: { connection, triggers },
+			tip:
+				triggers.length === 0
+					? `No triggers found for ${connection}.`
+					: `Use smithery trigger get ${connection} <name> to inspect a trigger schema.`,
+		})
+	} catch (error) {
+		fatal("Failed to list triggers", error)
+	}
+}
+
+export async function getTrigger(
+	connection: string,
+	name: string,
+	id: string | undefined,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		if (id) {
+			const trigger = await session.getTriggerInstance(connection, name, id)
+			outputDetail({
+				data: {
+					id: trigger.id,
+					connection,
+					name: trigger.name,
+					params: trigger.params,
+					createdAt: trigger.created_at,
+				},
+				tip: `Use smithery trigger unsubscribe ${connection} ${name} ${id} to delete this trigger.`,
+			})
+			return
+		}
+
+		const trigger = await session.getTrigger(connection, name)
+		outputDetail({
+			data: {
+				connection,
+				name: trigger.name,
+				description: trigger.description,
+				delivery: trigger.delivery,
+				inputSchema: trigger.inputSchema,
+				payloadSchema: trigger.payloadSchema,
+			},
+			tip: `Use smithery trigger subscribe ${connection} ${name} [params] to create a trigger.`,
+		})
+	} catch (error) {
+		fatal("Failed to get trigger", error)
+	}
+}
+
+export async function subscribeTrigger(
+	connection: string,
+	name: string,
+	paramsJson: string | undefined,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const params =
+			parseJsonObject<Record<string, unknown>>(paramsJson, "Params") ?? {}
+		const session = await ConnectSession.create(options.namespace)
+		const trigger = await session.createTrigger(connection, name, params)
+
+		outputDetail({
+			data: {
+				id: trigger.id,
+				connection,
+				name: trigger.name,
+				params: trigger.params,
+				createdAt: trigger.created_at,
+			},
+			tip: `Use smithery trigger unsubscribe ${connection} ${name} ${trigger.id} to delete this trigger.`,
+		})
+	} catch (error) {
+		fatal("Failed to subscribe to trigger", error)
+	}
+}
+
+export async function unsubscribeTrigger(
+	connection: string,
+	name: string,
+	id: string,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		await session.deleteTrigger(connection, name, id)
+
+		if (isJsonMode()) {
+			outputJson({ removed: [{ connection, name, id }] })
+			return
+		}
+
+		console.log(
+			`${pc.green("✓")} Removed trigger ${name} (${id}) from ${connection}`,
+		)
+	} catch (error) {
+		fatal("Failed to unsubscribe trigger", error)
+	}
+}
+
+export async function listSubscriptions(
+	connection: string | undefined,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		const subscriptions = await session.listSubscriptions(connection)
+		const data = subscriptions.map((subscription) => ({
+			id: subscription.id,
+			url: subscription.url,
+		}))
+
+		outputTable({
+			data,
+			columns: [
+				{ key: "id", header: "ID" },
+				{ key: "url", header: "URL" },
+			],
+			json: isJsonMode(),
+			jsonData: {
+				scope: connection ? "connection" : "namespace",
+				...(connection ? { connection } : {}),
+				subscriptions,
+			},
+			tip:
+				subscriptions.length === 0
+					? `No ${scopeLabel(connection)} subscriptions found.`
+					: `Use smithery trigger subscription add <url>${connection ? ` ${connection}` : ""} to register another webhook.`,
+		})
+	} catch (error) {
+		fatal("Failed to list subscriptions", error)
+	}
+}
+
+export async function createSubscription(
+	url: string,
+	connection: string | undefined,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		const subscription = await session.createSubscription(url, connection)
+
+		outputDetail({
+			data: {
+				id: subscription.id,
+				url: subscription.url,
+				scope: scopeLabel(connection),
+				connection,
+				secret: subscription.secret,
+			},
+			tip: "Store the secret securely. Smithery only returns it once.",
+		})
+	} catch (error) {
+		fatal("Failed to create subscription", error)
+	}
+}
+
+export async function removeSubscription(
+	id: string,
+	connection: string | undefined,
+	options: { namespace?: string },
+): Promise<void> {
+	try {
+		const session = await ConnectSession.create(options.namespace)
+		await session.deleteSubscription(id, connection)
+
+		if (isJsonMode()) {
+			outputJson({
+				removed: [{ id, ...(connection ? { connection } : {}) }],
+			})
+			return
+		}
+
+		console.log(
+			`${pc.green("✓")} Removed ${scopeLabel(connection)} subscription ${id}`,
+		)
+	} catch (error) {
+		fatal("Failed to remove subscription", error)
+	}
+}
+
+function scopeLabel(connection: string | undefined): string {
+	return connection ? "connection" : "namespace"
+}

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -12,7 +12,9 @@ import { parseJsonObject } from "./mcp/parse-json"
 
 function warnPreview(): void {
 	console.warn(
-		pc.yellow("Triggers are in draft. Breaking change may happen without notice."),
+		pc.yellow(
+			"Triggers are in draft. Breaking change may happen without notice.",
+		),
 	)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1428,8 +1428,8 @@ function getCommandPath(cmd: InstanceType<typeof Command>): string {
 }
 
 program.hook("preAction", async (_thisCommand, actionCommand) => {
-	const { trackEvent } = await import("./utils/analytics")
 	const commandPath = getCommandPath(actionCommand)
+	const { trackEvent } = await import("./utils/analytics")
 	const globalOpts = program.opts()
 	const localOpts = actionCommand.opts()
 	const allFlags = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,7 +338,7 @@ async function handleSubscribeTrigger(
 async function handleUnsubscribeTrigger(
 	connection: string,
 	name: string,
-	id: string,
+	id: string | undefined,
 	options: CliOptions,
 ) {
 	const { unsubscribeTrigger } = await import("./commands/trigger")
@@ -986,23 +986,26 @@ triggerCmd
 	.command("subscribe <connection> <name> [params]")
 	.description("Create a trigger instance")
 	.option("--namespace <ns>", "Namespace for the connection")
+	.option("--url <url>", "Webhook URL for trigger delivery")
+	.option("--id <id>", "Trigger subscription ID (defaults to a random UUID)")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  smithery trigger subscribe notion page.updated '{"workspace_id":"w_123"}'
-  smithery trigger subscribe github push`,
+  smithery trigger subscribe notion page.updated '{"workspace_id":"w_123"}' --url https://hook.new/i/...
+  smithery trigger subscribe scheduler alarm '{"in":"PT10S"}' --url https://hook.new/i/...`,
 	)
 	.action(handleSubscribeTrigger)
 
 triggerCmd
-	.command("unsubscribe <connection> <name> <id>")
+	.command("unsubscribe <connection> <name> [id]")
 	.description("Delete a trigger instance")
 	.option("--namespace <ns>", "Namespace for the connection")
 	.addHelpText(
 		"after",
 		`
 Examples:
+  smithery trigger unsubscribe notion page.updated
   smithery trigger unsubscribe notion page.updated trg_01HW...`,
 	)
 	.action(handleUnsubscribeTrigger)

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,67 @@ async function handleCallTool(
 	await callTool(connection, toolName, args, options)
 }
 
+async function handleListTriggers(connection: string, options: CliOptions) {
+	const { listTriggers } = await import("./commands/trigger")
+	await listTriggers(connection, options)
+}
+
+async function handleGetTrigger(
+	connection: string,
+	name: string,
+	id: string | undefined,
+	options: CliOptions,
+) {
+	const { getTrigger } = await import("./commands/trigger")
+	await getTrigger(connection, name, id, options)
+}
+
+async function handleSubscribeTrigger(
+	connection: string,
+	name: string,
+	params: string | undefined,
+	options: CliOptions,
+) {
+	const { subscribeTrigger } = await import("./commands/trigger")
+	await subscribeTrigger(connection, name, params, options)
+}
+
+async function handleUnsubscribeTrigger(
+	connection: string,
+	name: string,
+	id: string,
+	options: CliOptions,
+) {
+	const { unsubscribeTrigger } = await import("./commands/trigger")
+	await unsubscribeTrigger(connection, name, id, options)
+}
+
+async function handleListSubscriptions(
+	connection: string | undefined,
+	options: CliOptions,
+) {
+	const { listSubscriptions } = await import("./commands/trigger")
+	await listSubscriptions(connection, options)
+}
+
+async function handleCreateSubscription(
+	url: string,
+	connection: string | undefined,
+	options: CliOptions,
+) {
+	const { createSubscription } = await import("./commands/trigger")
+	await createSubscription(url, connection, options)
+}
+
+async function handleRemoveSubscription(
+	id: string,
+	connection: string | undefined,
+	options: CliOptions,
+) {
+	const { removeSubscription } = await import("./commands/trigger")
+	await removeSubscription(id, connection, options)
+}
+
 async function handleMcpAdd(
 	server: string | undefined,
 	options: CliOptions,
@@ -886,6 +947,108 @@ Examples:
   smithery tool call exa web_search_exa '{"query":"AI tools"}'`,
 	)
 	.action(handleCallTool)
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Trigger command — Discover and manage trigger webhooks for connections
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const triggerCmd = program
+	.command("trigger")
+	.description("Discover and manage trigger webhooks for connected MCP servers")
+
+triggerCmd
+	.command("list <connection>")
+	.description("List available triggers for a connection")
+	.option("--namespace <ns>", "Namespace for the connection")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger list notion
+  smithery trigger list github --json`,
+	)
+	.action(handleListTriggers)
+
+triggerCmd
+	.command("get <connection> <name> [id]")
+	.description("Get a trigger schema or trigger instance details")
+	.option("--namespace <ns>", "Namespace for the connection")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger get notion page.updated
+  smithery trigger get notion page.updated trg_01HW...`,
+	)
+	.action(handleGetTrigger)
+
+triggerCmd
+	.command("subscribe <connection> <name> [params]")
+	.description("Create a trigger instance")
+	.option("--namespace <ns>", "Namespace for the connection")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger subscribe notion page.updated '{"workspace_id":"w_123"}'
+  smithery trigger subscribe github push`,
+	)
+	.action(handleSubscribeTrigger)
+
+triggerCmd
+	.command("unsubscribe <connection> <name> <id>")
+	.description("Delete a trigger instance")
+	.option("--namespace <ns>", "Namespace for the connection")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger unsubscribe notion page.updated trg_01HW...`,
+	)
+	.action(handleUnsubscribeTrigger)
+
+const subscriptionCmd = triggerCmd
+	.command("subscription")
+	.description("Manage trigger webhook subscriptions")
+
+subscriptionCmd
+	.command("list [connection]")
+	.description("List namespace or connection webhook subscriptions")
+	.option("--namespace <ns>", "Namespace for the subscription")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger subscription list
+  smithery trigger subscription list notion`,
+	)
+	.action(handleListSubscriptions)
+
+subscriptionCmd
+	.command("add <url> [connection]")
+	.description("Create a namespace or connection webhook subscription")
+	.option("--namespace <ns>", "Namespace for the subscription")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger subscription add https://my-app.example.com/events
+  smithery trigger subscription add https://my-app.example.com/events notion`,
+	)
+	.action(handleCreateSubscription)
+
+subscriptionCmd
+	.command("remove <id> [connection]")
+	.description("Delete a namespace or connection webhook subscription")
+	.option("--namespace <ns>", "Namespace for the subscription")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  smithery trigger subscription remove sub_01HW...
+  smithery trigger subscription remove sub_01HW... notion`,
+	)
+	.action(handleRemoveSubscription)
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Event command (hidden/alpha) — Subscribe to event streams from MCP servers

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,6 +1,18 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { z } from "zod"
 
+export const TriggerSchema = z.object({
+	name: z.string(),
+	description: z.string().optional(),
+	delivery: z.array(z.string()).optional(),
+	inputSchema: z.record(z.string(), z.unknown()).optional(),
+	payloadSchema: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const ListTriggersResultSchema = z.object({
+	events: z.array(TriggerSchema),
+})
+
 export const EventTopicSchema = z.object({
 	topic: z.string(),
 	name: z.string(),
@@ -17,6 +29,27 @@ export const ListEventTopicsResultSchema = z.object({
 export const EmptyEventResultSchema = z.object({}).passthrough()
 
 export type EventTopic = z.infer<typeof EventTopicSchema>
+export type TriggerDescriptor = z.infer<typeof TriggerSchema>
+
+export async function listEventTriggers(client: Client) {
+	try {
+		// biome-ignore lint/suspicious/noExplicitAny: custom JSON-RPC method not in SDK types
+		return await (client.request as any)(
+			{ method: "ai.smithery/events/list" },
+			ListTriggersResultSchema,
+		)
+	} catch {
+		const { eventTopics } = await listEventTopics(client)
+		return {
+			events: eventTopics.map((topic) => ({
+				name: topic.topic,
+				description: topic.description,
+				inputSchema: topic.inputSchema,
+				payloadSchema: topic.eventSchema,
+			})),
+		}
+	}
+}
 
 /**
  * List all event topics from an MCP server supporting ai.smithery/events.


### PR DESCRIPTION
### What's added in this PR?

- Adds a new `smithery trigger` command group for listing trigger types, inspecting schemas or instances, creating trigger subscriptions, and deleting them.
- Adds `trigger subscription` subcommands for namespace-scoped and connection-scoped webhook subscription management.
- Extends `ConnectSession` with the Smithery trigger and subscription REST endpoints, plus tests that cover both command wiring and endpoint path construction.
- Validation: `pnpm check`, `pnpm build`, `pnpm test`, and `pnpm typecheck`.

#### Screenshots

- Not applicable.

### What's the issues or discussion related to this PR ?

- Smithery added trigger support, but the CLI could not yet discover trigger types, create trigger instances, or manage webhook subscription endpoints from the command line.
- This PR exposes the documented trigger workflow in the CLI so users can work with the new feature without dropping down to raw REST calls.
