### PR TITLE
feat(SMI-1839): download and run MCPB bundles via uplink on mcp add

### DIFF
--- a/src/commands/__tests__/mcp-add-uplink.test.ts
+++ b/src/commands/__tests__/mcp-add-uplink.test.ts
@@ -7,6 +7,8 @@ const {
 	mockDeleteConnection,
 	mockCreateSession,
 	mockServeUplink,
+	mockResolveServer,
+	mockAddBundleUplinkServer,
 } = vi.hoisted(() => {
 	const addServerImpl = vi.fn()
 	const createConnection = vi.fn()
@@ -19,6 +21,8 @@ const {
 		getNamespace: () => "calclavia",
 	}))
 	const serveUplink = vi.fn(async () => 0)
+	const resolveServer = vi.fn()
+	const addBundleUplinkServer = vi.fn(async () => {})
 
 	return {
 		mockAddServerImpl: addServerImpl,
@@ -27,6 +31,8 @@ const {
 		mockDeleteConnection: deleteConnection,
 		mockCreateSession: createSession,
 		mockServeUplink: serveUplink,
+		mockResolveServer: resolveServer,
+		mockAddBundleUplinkServer: addBundleUplinkServer,
 	}
 })
 
@@ -47,6 +53,14 @@ vi.mock("../../lib/uplink", async () => {
 		serveUplink: mockServeUplink,
 	}
 })
+
+vi.mock("../../lib/registry", () => ({
+	resolveServer: mockResolveServer,
+}))
+
+vi.mock("../mcp/add-uplink-bundle", () => ({
+	addBundleUplinkServer: mockAddBundleUplinkServer,
+}))
 
 import { addServer } from "../mcp/add"
 
@@ -145,5 +159,92 @@ describe("mcp add uplink routing", () => {
 		expect(mockCreateConnection).not.toHaveBeenCalled()
 		expect(mockSetConnection).not.toHaveBeenCalled()
 		expect(mockServeUplink).not.toHaveBeenCalled()
+	})
+
+	test("routes a registry server with bundleUrl to the bundle uplink path", async () => {
+		const stdioConnection = {
+			type: "stdio" as const,
+			configSchema: {},
+			bundleUrl: "https://cdn.smithery.ai/bundles/foo.mcpb",
+		}
+		mockResolveServer.mockResolvedValue({
+			server: { qualifiedName: "acme/foo" },
+			connection: stdioConnection,
+		})
+
+		await addServer("acme/foo", { id: "my-foo" })
+
+		expect(mockAddBundleUplinkServer).toHaveBeenCalledWith(
+			{
+				qualifiedName: "acme/foo",
+				bundleUrl: "https://cdn.smithery.ai/bundles/foo.mcpb",
+				connection: stdioConnection,
+				server: { qualifiedName: "acme/foo" },
+			},
+			{ id: "my-foo" },
+		)
+		expect(mockAddServerImpl).not.toHaveBeenCalled()
+		expect(mockServeUplink).not.toHaveBeenCalled()
+	})
+
+	test("falls through to the http flow when registry returns an http connection", async () => {
+		mockResolveServer.mockResolvedValue({
+			server: { qualifiedName: "acme/bar" },
+			connection: {
+				type: "http",
+				configSchema: {},
+				deploymentUrl: "https://bar.example.com/mcp",
+			},
+		})
+
+		await addServer("acme/bar", {})
+
+		expect(mockAddBundleUplinkServer).not.toHaveBeenCalled()
+		expect(mockAddServerImpl).toHaveBeenCalledWith(
+			"acme/bar",
+			expect.objectContaining({ name: undefined }),
+		)
+	})
+
+	test("falls through when registry returns a stdio connection without bundleUrl", async () => {
+		mockResolveServer.mockResolvedValue({
+			server: { qualifiedName: "acme/legacy" },
+			connection: {
+				type: "stdio",
+				configSchema: {},
+				stdioFunction: "() => ({ command: 'node' })",
+			},
+		})
+
+		await addServer("acme/legacy", {})
+
+		expect(mockAddBundleUplinkServer).not.toHaveBeenCalled()
+		expect(mockAddServerImpl).toHaveBeenCalledWith(
+			"acme/legacy",
+			expect.objectContaining({ name: undefined }),
+		)
+	})
+
+	test("falls through when registry resolution fails", async () => {
+		mockResolveServer.mockRejectedValue(new Error("server not found"))
+
+		await addServer("acme/unknown", {})
+
+		expect(mockAddBundleUplinkServer).not.toHaveBeenCalled()
+		expect(mockAddServerImpl).toHaveBeenCalledWith(
+			"acme/unknown",
+			expect.objectContaining({ name: undefined }),
+		)
+	})
+
+	test("skips the registry probe for explicit http urls", async () => {
+		await addServer("https://server.smithery.ai/exa", {})
+
+		expect(mockResolveServer).not.toHaveBeenCalled()
+		expect(mockAddBundleUplinkServer).not.toHaveBeenCalled()
+		expect(mockAddServerImpl).toHaveBeenCalledWith(
+			"https://server.smithery.ai/exa",
+			expect.objectContaining({ name: undefined }),
+		)
 	})
 })

--- a/src/commands/mcp/add-flow.ts
+++ b/src/commands/mcp/add-flow.ts
@@ -14,7 +14,6 @@ export async function finalizeAddedConnection(
 		name?: string
 		metadata?: Record<string, unknown>
 		headers?: Record<string, string>
-		unstableWebhookUrl?: string
 	},
 ): Promise<Connection> {
 	let current = connection
@@ -34,7 +33,6 @@ export async function finalizeAddedConnection(
 			name: options.name,
 			metadata: options.metadata,
 			headers: Object.keys(headers).length > 0 ? headers : undefined,
-			unstableWebhookUrl: options.unstableWebhookUrl,
 		})
 		currentUrl = requireConnectionUrl(current)
 	}

--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -18,7 +18,6 @@ export async function addServer(
 		headers?: string
 		namespace?: string
 		force?: boolean
-		unstableWebhookUrl?: string
 	},
 ): Promise<void> {
 	try {
@@ -77,14 +76,12 @@ export async function addServer(
 			name: options.name,
 			metadata: parsedMetadata,
 			headers: parsedHeaders,
-			unstableWebhookUrl: options.unstableWebhookUrl,
 		})
 
 		const finalConnection = await finalizeAddedConnection(session, connection, {
 			name: options.name,
 			metadata: parsedMetadata,
 			headers: parsedHeaders,
-			unstableWebhookUrl: options.unstableWebhookUrl,
 		})
 
 		if (finalConnection.status?.state === "auth_required") {

--- a/src/commands/mcp/add-uplink-bundle.ts
+++ b/src/commands/mcp/add-uplink-bundle.ts
@@ -1,0 +1,120 @@
+import type { ServerGetResponse } from "@smithery/api/resources/servers/servers"
+import pc from "picocolors"
+import { fatal } from "../../lib/cli-error"
+import { saveConfig } from "../../lib/keychain"
+import { verbose } from "../../lib/logger"
+import { ensureBundleInstalled, getHydratedBundleCommand } from "../../lib/mcpb"
+import { serveUplink } from "../../lib/uplink"
+import { parseServerConfig } from "../../utils/cli-utils"
+import { resolveUserConfig } from "../../utils/install/user-config"
+import { createSpinner } from "../../utils/spinner"
+import { ConnectSession } from "./api"
+import { parseJsonObject } from "./parse-json"
+
+export interface BundleAddTarget {
+	qualifiedName: string
+	bundleUrl: string
+	connection: ServerGetResponse.StdioConnection
+	server: ServerGetResponse
+}
+
+export interface BundleAddOptions {
+	id?: string
+	name?: string
+	namespace?: string
+	metadata?: string
+	headers?: string
+	config?: string
+	force?: boolean
+}
+
+export async function addBundleUplinkServer(
+	bundle: BundleAddTarget,
+	options: BundleAddOptions,
+): Promise<void> {
+	try {
+		if (options.headers !== undefined) {
+			throw new Error("--headers is not supported for uplink connections.")
+		}
+
+		const configOverride = options.config
+			? parseServerConfig(options.config)
+			: {}
+		const parsedMetadata = parseJsonObject(options.metadata, "Metadata")
+
+		const spinner = createSpinner(`Preparing ${bundle.qualifiedName}...`)
+		let userConfig: Record<string, unknown>
+		let hydrated: {
+			command: string
+			args: string[]
+			env: Record<string, string>
+		}
+		try {
+			userConfig = await resolveUserConfig(
+				bundle.connection,
+				bundle.qualifiedName,
+				configOverride,
+				spinner,
+			)
+
+			if (Object.keys(userConfig).length > 0) {
+				await saveConfig(bundle.qualifiedName, userConfig)
+			}
+
+			const bundleDir = await ensureBundleInstalled(
+				bundle.qualifiedName,
+				bundle.bundleUrl,
+			)
+			hydrated = getHydratedBundleCommand(bundleDir, userConfig)
+			spinner.success(pc.dim(`Prepared ${bundle.qualifiedName}`))
+		} catch (error) {
+			spinner.error(`Failed to prepare ${bundle.qualifiedName}`)
+			throw error
+		}
+
+		verbose(
+			`Hydrated bundle command: ${hydrated.command} ${hydrated.args.join(" ")}`,
+		)
+
+		const name = options.name ?? options.id ?? bundle.qualifiedName
+		const session = await ConnectSession.create(options.namespace)
+		const connection = options.id
+			? await session.setConnection(options.id, undefined, {
+					name,
+					metadata: parsedMetadata,
+					transport: "uplink",
+				})
+			: await session.createConnection(undefined, {
+					name,
+					metadata: parsedMetadata,
+					transport: "uplink",
+				})
+
+		const namespace = session.getNamespace()
+		console.log(
+			`Creating connection ${namespace}/${connection.connectionId} ... ok`,
+		)
+
+		let exitCode = 0
+		try {
+			exitCode = await serveUplink({
+				namespace,
+				connectionId: connection.connectionId,
+				target: {
+					kind: "uplink-stdio",
+					command: hydrated.command,
+					args: hydrated.args,
+					env: hydrated.env,
+				},
+				force: options.force,
+			})
+		} finally {
+			await session.deleteConnection(connection.connectionId).catch(() => {})
+		}
+		if (exitCode !== 0) {
+			process.exit(exitCode)
+		}
+	} catch (error) {
+		fatal("Failed to add connection", error)
+	}
+}

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -1,26 +1,34 @@
 import { fatal } from "../../lib/cli-error"
+import { verbose } from "../../lib/logger"
+import { resolveServer } from "../../lib/registry"
 import { serveUplink, type UplinkTarget } from "../../lib/uplink"
+import { parseQualifiedName } from "../../utils/cli-utils"
 import { finalizeAddedConnection } from "./add-flow"
 import { addServer as addServerImpl } from "./add-impl"
+import {
+	addBundleUplinkServer,
+	type BundleAddTarget,
+} from "./add-uplink-bundle"
 import { ConnectSession } from "./api"
 import { normalizeMcpUrl } from "./normalize-url"
 import { outputConnectionDetail } from "./output-connection"
 import { parseJsonObject } from "./parse-json"
 import { classifyAddTarget } from "./uplink-target"
 
+interface AddServerOptions {
+	id?: string
+	name?: string
+	namespace?: string
+	metadata?: string
+	headers?: string
+	config?: string
+	force?: boolean
+	uplinkCommand?: string[]
+}
+
 export async function addServer(
 	server: string | undefined,
-	options: {
-		id?: string
-		name?: string
-		namespace?: string
-		metadata?: string
-		headers?: string
-		config?: string
-		force?: boolean
-		uplinkCommand?: string[]
-		unstableWebhookUrl?: string
-	},
+	options: AddServerOptions,
 ): Promise<void> {
 	const target = await classifyAddTarget({
 		server,
@@ -29,6 +37,16 @@ export async function addServer(
 
 	if (target.kind !== "http") {
 		return addUplinkServer(target, options)
+	}
+
+	// Qualified names (non-URL inputs) may resolve to a local bundle server;
+	// in that case download the bundle and run it behind an uplink. Explicit
+	// http(s) URLs skip the registry probe.
+	if (server && !isHttpUrl(server)) {
+		const bundleTarget = await tryResolveBundleTarget(server)
+		if (bundleTarget) {
+			return addBundleUplinkServer(bundleTarget, options)
+		}
 	}
 
 	const mcpUrl = target.server
@@ -53,7 +71,6 @@ export async function addServer(
 					name,
 					metadata: parsedMetadata,
 					headers: parsedHeaders,
-					unstableWebhookUrl: options.unstableWebhookUrl,
 				},
 			)
 			const finalConnection = await finalizeAddedConnection(
@@ -63,7 +80,6 @@ export async function addServer(
 					name,
 					metadata: parsedMetadata,
 					headers: parsedHeaders,
-					unstableWebhookUrl: options.unstableWebhookUrl,
 				},
 			)
 			outputConnectionDetail({
@@ -79,18 +95,44 @@ export async function addServer(
 	return addServerImpl(mcpUrl, { ...options, name })
 }
 
+function isHttpUrl(value: string): boolean {
+	return value.startsWith("http://") || value.startsWith("https://")
+}
+
+async function tryResolveBundleTarget(
+	server: string,
+): Promise<BundleAddTarget | null> {
+	let parsed: ReturnType<typeof parseQualifiedName>
+	try {
+		parsed = parseQualifiedName(server)
+	} catch {
+		return null
+	}
+
+	try {
+		const { server: serverDetails, connection } = await resolveServer(parsed)
+		if (connection.type !== "stdio" || !connection.bundleUrl) {
+			return null
+		}
+		return {
+			qualifiedName: serverDetails.qualifiedName,
+			bundleUrl: connection.bundleUrl,
+			connection,
+			server: serverDetails,
+		}
+	} catch (error) {
+		verbose(
+			`Registry lookup failed for ${server}; falling back to URL-proxy flow: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		)
+		return null
+	}
+}
+
 async function addUplinkServer(
 	target: UplinkTarget,
-	options: {
-		id?: string
-		name?: string
-		namespace?: string
-		metadata?: string
-		headers?: string
-		config?: string
-		force?: boolean
-		unstableWebhookUrl?: string
-	},
+	options: AddServerOptions,
 ): Promise<void> {
 	try {
 		if (options.headers !== undefined) {
@@ -99,12 +141,6 @@ async function addUplinkServer(
 
 		if (options.config) {
 			throw new Error("--config is not supported for uplink connections.")
-		}
-
-		if (options.unstableWebhookUrl) {
-			throw new Error(
-				"--unstableWebhookUrl is not supported for uplink connections.",
-			)
 		}
 
 		const parsedMetadata = parseJsonObject(options.metadata, "Metadata")

--- a/src/commands/mcp/api.ts
+++ b/src/commands/mcp/api.ts
@@ -49,9 +49,7 @@ type SmitheryClient = Awaited<ReturnType<typeof createSmitheryClient>>
 type ConnectionWriteOptions = Pick<
 	ConnectionCreateParams,
 	"name" | "metadata" | "headers" | "transport"
-> & {
-	unstableWebhookUrl?: string
-}
+>
 
 type ConnectionsListQuery = ConnectionListParams &
 	Record<`metadata.${string}`, string>
@@ -334,9 +332,6 @@ function buildConnectionBody(
 		...(options.metadata ? { metadata: options.metadata } : {}),
 		...(options.headers ? { headers: options.headers } : {}),
 		...(options.transport ? { transport: options.transport } : {}),
-		...(options.unstableWebhookUrl && {
-			unstableWebhookUrl: options.unstableWebhookUrl,
-		}),
 	}
 	return body
 }

--- a/src/commands/mcp/uplink-target.ts
+++ b/src/commands/mcp/uplink-target.ts
@@ -31,7 +31,6 @@ const OPTIONS_WITH_VALUES = new Set([
 	"--metadata",
 	"--headers",
 	"--namespace",
-	"--unstableWebhookUrl",
 	"-c",
 	"--client",
 	"--config",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ interface CliOptions {
 	up?: boolean
 	down?: boolean
 	model?: string
-	unstableWebhookUrl?: string
 	uplinkCommand?: string[]
 }
 
@@ -622,10 +621,6 @@ mcpCmd
 	.option(
 		"--force",
 		"Create a duplicate HTTP connection, or take over an existing uplink pair",
-	)
-	.option(
-		"--unstableWebhookUrl <url>",
-		"Webhook URL for receiving server-to-client messages (unstable)",
 	)
 	.option(
 		"-c, --client <name>",

--- a/src/lib/mcpb.ts
+++ b/src/lib/mcpb.ts
@@ -1,15 +1,13 @@
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
-import {
-	type McpbUserConfigurationOption,
-	unpackExtension,
-} from "@anthropic-ai/mcpb"
+import type { McpbUserConfigurationOption } from "@anthropic-ai/mcpb"
 import type { ServerCard } from "@smithery/api/resources/servers/releases"
 import { strFromU8, unzipSync } from "fflate"
 import type { JSONSchema } from "../types/registry.js"
 import type { StdioDeployPayload } from "./deploy-payload.js"
 import { verbose } from "./logger.js"
+import { createSmitheryClient } from "./smithery-client.js"
 
 const BUNDLE_FILENAME = "server.mcpb"
 const CACHE_META_FILENAME = ".metadata.json"
@@ -52,6 +50,97 @@ function isBundleCached(qualifiedName: string): boolean {
 	return fs.existsSync(manifestPath)
 }
 
+function isAbsoluteUrl(value: string): boolean {
+	return value.startsWith("http://") || value.startsWith("https://")
+}
+
+/**
+ * Fetches the bundle bytes either via the Smithery SDK download endpoint
+ * (when the registry returns a relative bundleUrl) or directly from an
+ * absolute URL (legacy/external hosting).
+ */
+async function fetchBundle(
+	qualifiedName: string,
+	bundleUrl: string,
+): Promise<Response> {
+	if (isAbsoluteUrl(bundleUrl)) {
+		return fetch(bundleUrl)
+	}
+	const client = await createSmitheryClient()
+	return client.servers.download(qualifiedName)
+}
+
+async function headBundle(bundleUrl: string): Promise<Response | null> {
+	if (!isAbsoluteUrl(bundleUrl)) return null
+	return fetch(bundleUrl, { method: "HEAD" })
+}
+
+function extractMcpb(mcpbPath: string, outputDir: string): void {
+	const fileContent = fs.readFileSync(mcpbPath)
+	const decompressed = unzipSync(fileContent)
+	const resolvedOutputDir = path.resolve(outputDir)
+	const fileModes =
+		process.platform === "win32"
+			? new Map<string, number>()
+			: readZipUnixModes(fileContent)
+	for (const [relativePath, data] of Object.entries(decompressed)) {
+		// Skip bare directory entries; their parents are created on demand.
+		if (relativePath.endsWith("/")) {
+			continue
+		}
+		const fullPath = path.join(resolvedOutputDir, relativePath)
+		const normalized = path.resolve(fullPath)
+		if (
+			!normalized.startsWith(resolvedOutputDir + path.sep) &&
+			normalized !== resolvedOutputDir
+		) {
+			throw new Error(`Path traversal attempt detected: ${relativePath}`)
+		}
+		fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+		fs.writeFileSync(fullPath, data)
+		const mode = fileModes.get(relativePath)
+		if (mode !== undefined) {
+			try {
+				fs.chmodSync(fullPath, mode)
+			} catch {
+				// Permission restoration is best-effort.
+			}
+		}
+	}
+}
+
+/** Parse the ZIP central directory to recover Unix file permission bits. */
+function readZipUnixModes(zip: Buffer): Map<string, number> {
+	const modes = new Map<string, number>()
+	let eocd = -1
+	for (let i = zip.length - 22; i >= 0; i--) {
+		if (zip.readUInt32LE(i) === 0x06054b50) {
+			eocd = i
+			break
+		}
+	}
+	if (eocd < 0) return modes
+	const centralDirOffset = zip.readUInt32LE(eocd + 16)
+	const entries = zip.readUInt16LE(eocd + 8)
+	let offset = centralDirOffset
+	for (let i = 0; i < entries; i++) {
+		if (zip.readUInt32LE(offset) !== 0x02014b50) break
+		const externalAttrs = zip.readUInt32LE(offset + 38)
+		const filenameLength = zip.readUInt16LE(offset + 28)
+		const extraLength = zip.readUInt16LE(offset + 30)
+		const commentLength = zip.readUInt16LE(offset + 32)
+		const filename = zip.toString(
+			"utf8",
+			offset + 46,
+			offset + 46 + filenameLength,
+		)
+		const mode = (externalAttrs >> 16) & 0o777
+		if (mode > 0) modes.set(filename, mode)
+		offset += 46 + filenameLength + extraLength + commentLength
+	}
+	return modes
+}
+
 /**
  * Checks if a bundle needs to be updated by comparing ETags
  * Uses a lightweight HEAD request to avoid downloading the entire bundle
@@ -69,9 +158,14 @@ async function needsBundleUpdate(
 	}
 
 	try {
-		// Make a HEAD request to get ETag without downloading the file
-		verbose(`Checking for updates: ${bundleUrl}`)
-		const response = await fetch(bundleUrl, { method: "HEAD" })
+		verbose(`Checking for updates: ${qualifiedName}`)
+		const response = await headBundle(bundleUrl)
+		if (!response) {
+			verbose(
+				`HEAD not supported for ${qualifiedName}; will re-download to verify`,
+			)
+			return true
+		}
 
 		if (!response.ok) {
 			verbose(`HEAD request failed: ${response.status} ${response.statusText}`)
@@ -120,15 +214,16 @@ async function needsBundleUpdate(
 }
 
 /**
- * Downloads a bundle file from a URL and returns the response for metadata extraction
+ * Downloads a bundle file and returns the response headers for cache metadata.
  */
 async function downloadBundle(
+	qualifiedName: string,
 	bundleUrl: string,
 	destinationPath: string,
 ): Promise<{ etag: string | null; lastModified: string | null }> {
-	verbose(`Downloading bundle from: ${bundleUrl}`)
+	verbose(`Downloading bundle for ${qualifiedName} (source: ${bundleUrl})`)
 
-	const response = await fetch(bundleUrl)
+	const response = await fetchBundle(qualifiedName, bundleUrl)
 	if (!response.ok) {
 		throw new Error(
 			`Failed to download bundle: ${response.status} ${response.statusText}`,
@@ -150,7 +245,7 @@ async function downloadBundle(
 /**
  * Downloads and extracts a bundle to the local cache
  * @param qualifiedName - Server qualified name (e.g., user/server)
- * @param bundleUrl - URL to download the .mcpb bundle from
+ * @param bundleUrl - URL or registry-relative path to the .mcpb bundle
  * @returns Path to the extracted bundle directory
  */
 async function downloadAndExtractBundle(
@@ -164,20 +259,17 @@ async function downloadAndExtractBundle(
 
 	// Download bundle
 	const mcpbPath = path.join(bundleDir, BUNDLE_FILENAME)
-	const { etag, lastModified } = await downloadBundle(bundleUrl, mcpbPath)
-
-	// Extract bundle using @anthropic/mcpb CLI
-	verbose(`Extracting bundle to: ${bundleDir}`)
-	const success = await unpackExtension({
+	const { etag, lastModified } = await downloadBundle(
+		qualifiedName,
+		bundleUrl,
 		mcpbPath,
-		outputDir: bundleDir,
-		silent: true,
-	})
+	)
 
-	if (!success) {
-		throw new Error("Failed to extract bundle")
-	}
-
+	// Extract bundle. We unpack with fflate directly because some bundles
+	// include bare directory entries (e.g. "server/") that the upstream
+	// unpacker writes as files, which fails on POSIX.
+	verbose(`Extracting bundle to: ${bundleDir}`)
+	extractMcpb(mcpbPath, bundleDir)
 	verbose("Bundle extracted successfully")
 
 	// Save cache metadata for future ETag comparisons
@@ -267,6 +359,11 @@ export function hydrateBundleCommand(
 	args: string[]
 	env: Record<string, string>
 } {
+	const resolvedCommand = resolveTemplateString(
+		bundleCommand.command,
+		userConfig,
+		bundleDir,
+	)
 	const resolvedArgs = bundleCommand.args.map((arg) =>
 		resolveTemplateString(arg, userConfig, bundleDir),
 	)
@@ -279,7 +376,7 @@ export function hydrateBundleCommand(
 	}
 
 	return {
-		command: bundleCommand.command,
+		command: resolvedCommand,
 		args: resolvedArgs,
 		env: resolvedEnv,
 	}

--- a/src/lib/uplink.ts
+++ b/src/lib/uplink.ts
@@ -31,6 +31,7 @@ export type UplinkTarget =
 			kind: "uplink-stdio"
 			command: string
 			args: string[]
+			env?: Record<string, string>
 	  }
 
 export interface LocalPeer {
@@ -132,7 +133,11 @@ export async function serveUplink(options: {
 	const local: LocalPeer =
 		options.target.kind === "uplink-http"
 			? createHttpLocalPeer(options.target.mcpUrl)
-			: createStdioLocalPeer(options.target.command, options.target.args)
+			: createStdioLocalPeer(
+					options.target.command,
+					options.target.args,
+					options.target.env,
+				)
 
 	let activeSocket: WebSocket | null = null
 	let disposeBridge: (() => void) | undefined
@@ -574,7 +579,11 @@ function isInitializedNotification(message: JSONRPCMessage): boolean {
 	)
 }
 
-function createStdioLocalPeer(command: string, args: string[]): LocalPeer {
+function createStdioLocalPeer(
+	command: string,
+	args: string[],
+	extraEnv?: Record<string, string>,
+): LocalPeer {
 	const resolved = resolveSpawnCommand(command, args)
 	let child: ReturnType<typeof spawn> | null = null
 
@@ -584,7 +593,10 @@ function createStdioLocalPeer(command: string, args: string[]): LocalPeer {
 				const readBuffer = new ReadBuffer()
 				child = spawn(resolved.command, resolved.args, {
 					cwd: process.cwd(),
-					env: getRuntimeEnvironment(getStringEnv(process.env)),
+					env: getRuntimeEnvironment({
+						...getStringEnv(process.env),
+						...(extraEnv ?? {}),
+					}),
 					stdio: ["pipe", "pipe", "inherit"],
 					shell: false,
 				})


### PR DESCRIPTION
## Summary
- `smithery mcp add <qualifiedName>` now detects when the registry server is a local **MCPB bundle** (`stdio` connection with a non-empty `bundleUrl`). Instead of creating a URL-proxy connection, the CLI downloads the bundle, prompts for `user_config` via the existing keychain pipeline, hydrates the bundle's command/args/env, and runs the process locally behind a Smithery uplink.
- `--config` is now accepted for bundle-backed uplinks (merged into the prompt pipeline, same semantics as `smithery run`). It remains rejected for the other uplink variants.
- Explicit `http(s)://` URLs and URLs resolving to loopback behave exactly as before — the registry probe only runs for qualified-name inputs.
- `--unstableWebhookUrl` is removed from `mcp add` entirely (no longer valid).

## Implementation notes
- `UplinkTarget.uplink-stdio` gains an optional `env` carrier. `createRawStdioLocalPeer` now merges `{...process.env, ...extraEnv}` before handing to `getRuntimeEnvironment`, so manifest-hydrated env vars win over the inherited shell environment.
- New `src/commands/mcp/add-uplink-bundle.ts` mirrors the `installServer` flow: `resolveUserConfig` → `saveConfig` → `ensureBundleInstalled` → `getHydratedBundleCommand` → `ConnectSession.setConnection`/`createConnection` with `transport: "uplink"` → `serveUplink`. Teardown in `finally` calls `deleteConnection` when the uplink exits.
- `addServer` gets a small registry-probe step for qualified-name inputs. If the probe fails (404, auth error, etc.) or the returned connection doesn't have a `bundleUrl`, the flow falls through to the existing URL-proxy path.

## Test plan
- [x] `pnpm typecheck`, `pnpm exec biome check`, `pnpm test` (428 tests passing)
- [x] Unit: 5 new routing tests in `mcp-add-uplink.test.ts` cover bundle routing, http-connection fallthrough, legacy-stdio fallthrough, registry-failure fallthrough, and http-URL skip.
- [x] End-to-end: packed a real `.mcpb` with `@anthropic-ai/mcpb`, served it over localhost, drove `addBundleUplinkServer` directly. Bundle downloaded → cached at `~/.smithery/cache/servers/...` → spawned with hydrated env → uplink paired with Smithery gateway → `smithery tool list <id>` returned `marker=hello-from-bundle-env` (confirming env propagation) → clean SIGINT teardown removed the Smithery connection.
- [x] Regression check: `smithery mcp add exa` (remote HTTP server) still lands through the existing URL-proxy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)