### PR TITLE
chore: hide homepage command from public help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1242,9 +1242,9 @@ namespace
 		await createNamespace(name)
 	})
 
-// Homepage command
+// Homepage command (hidden — not GA, may be removed)
 const homepageCmd = program
-	.command("homepage")
+	.command("homepage", { hidden: true })
 	.description("Manage the Smithery homepage dashboard")
 
 homepageCmd


### PR DESCRIPTION
## Summary
- Marks `smithery homepage` (and its `up`/`down`/`status` subcommands) as hidden from `--help` output
- Subcommands still work when invoked directly — this is a "not GA, may be removed" pattern, matching how `mcp secrets` and `mcp logs` are already hidden in `src/index.ts`

## Why
We may pull this command in the future and don't want users to depend on it as a public surface in the 1.0.0 release.

## Test plan
- [x] `pnpm run build` succeeds
- [x] `node dist/index.js --help` no longer lists `homepage`
- [x] `node dist/index.js homepage --help` still works and shows subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)