### PR TITLE
fix(mcp add): resume setup when re-adding incomplete connection

### DIFF
--- a/src/commands/mcp/add-impl.ts
+++ b/src/commands/mcp/add-impl.ts
@@ -6,6 +6,7 @@ import {
 	finalizeAddedConnection,
 } from "./add-flow"
 import { ConnectSession } from "./api"
+import { isInputRequiredStatus } from "./connection-status"
 import { normalizeMcpUrl } from "./normalize-url"
 import { outputConnectionDetail } from "./output-connection"
 import { parseJsonObject } from "./parse-json"
@@ -43,9 +44,16 @@ export async function addServer(
 						`Connection already exists for this URL: ${match.name} (${match.connectionId}, status: ${status})`,
 					),
 				)
-				if (status === "auth_required") {
+				if (isInputRequiredStatus(match.status)) {
+					match = await finalizeAddedConnection(session, match, {
+						name: options.name,
+						metadata: parsedMetadata,
+						headers: parsedHeaders,
+					})
+				}
+				if (match.status?.state === "auth_required") {
 					match = await completeConnectionAuthorization(session, match)
-				} else if (status === "connected") {
+				} else if (match.status?.state === "connected") {
 					console.error(
 						pc.yellow(
 							`Use "smithery tool list ${match.connectionId}" to interact with it.`,


### PR DESCRIPTION
## Summary
- Re-running \`smithery mcp add <url>\` on a connection stuck in \`input_required\` (missing headers/query) now resumes the prompt loop via \`finalizeAddedConnection\`, instead of only printing a remove/re-add tip.
- OAuth resume (\`auth_required\`) already worked; this closes the symmetric gap for header/query input.
- Non-TTY / JSON mode behavior is unchanged: the existing tip still prints because \`finalizeAddedConnection\` no-ops without a TTY.

## Why
If a user skipped header entry the first time (or had no TTY), there was no way back into the setup screen short of removing and re-adding. Re-running \`add\` on the same URL is the natural recovery path.

## Test plan
- [x] \`pnpm test\` (388 passed)
- [x] \`pnpm run build\`
- [ ] Manual: add a server requiring headers, decline prompts, re-run \`smithery mcp add <url>\`, confirm prompts re-appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)