### PR TITLE
fix: arb url install + node 24 consent crash

### DIFF
--- a/src/commands/mcp/install.ts
+++ b/src/commands/mcp/install.ts
@@ -4,6 +4,7 @@ import type { ValidClient } from "../../config/clients"
 import { getClientConfiguration } from "../../config/clients"
 import { fatal } from "../../lib/cli-error"
 import {
+	formatRemoteUrlConfig,
 	formatServerConfig,
 	readConfig,
 	runConfigCommand,
@@ -143,5 +144,98 @@ export async function installServer(
 			`Installation error: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
 		)
 		fatal("Failed to install server", error)
+	}
+}
+
+/**
+ * Installs an arbitrary remote MCP URL into a client's config under a
+ * caller-provided alias. Skips registry resolution entirely — this is the
+ * path for toolboxes (`https://mcp.smithery.run/<ns>`) and any other
+ * self-hosted MCP endpoint that doesn't live in the Smithery registry.
+ *
+ * The client must support an `http` transport. OAuth-capable clients get a
+ * native `{type: "http", url}` block; non-OAuth clients fall back to
+ * mcp-remote so the URL is reachable via stdio.
+ */
+export async function installRemoteUrlServer(
+	url: string,
+	alias: string,
+	client: ValidClient,
+): Promise<void> {
+	verbose(`Starting URL install of ${url} as ${alias} for client ${client}`)
+
+	await checkAnalyticsConsent()
+
+	const clientConfig = getClientConfiguration(client)
+	const httpTransport = clientConfig.transports?.http
+	if (!httpTransport) {
+		fatal(
+			`Client "${client}" does not support remote MCP URLs. Use a qualified server name (\`<namespace>/<server>\`) instead.`,
+		)
+	}
+
+	const transportType: "http-oauth" | "http-proxy" = httpTransport.supportsOAuth
+		? "http-oauth"
+		: "http-proxy"
+	const serverConfig = formatRemoteUrlConfig(url, transportType)
+	verbose(`Formatted server config: ${JSON.stringify(serverConfig, null, 2)}`)
+
+	try {
+		if (clientConfig.install.method === "command") {
+			runConfigCommand({ mcpServers: { [alias]: serverConfig } }, clientConfig)
+		} else {
+			const config = readConfig(client)
+			config.mcpServers[alias] = serverConfig
+			writeConfig(config, client)
+		}
+
+		if (isJsonMode()) {
+			console.log(
+				JSON.stringify({
+					success: true,
+					url,
+					alias,
+					client,
+					transport: transportType,
+					hint: `Restart ${client} to apply changes.`,
+				}),
+			)
+		} else {
+			console.log()
+			console.log(
+				pc.green(`✓ ${alias} (${url}) successfully installed for ${client}`),
+			)
+			showPostInstallHint(client)
+			await promptForRestart(client)
+		}
+		process.exit(0)
+	} catch (error) {
+		verbose(
+			`Installation error: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
+		)
+		fatal("Failed to install server", error)
+	}
+}
+
+export function isHttpUrl(value: string): boolean {
+	return value.startsWith("http://") || value.startsWith("https://")
+}
+
+/**
+ * Best-effort alias derivation when `--name` is omitted on a URL install.
+ * Returns null if no sensible alias can be derived — caller should fatal.
+ *
+ * Heuristic: take the URL hostname's first label minus a trailing TLD —
+ * `mcp.smithery.run` → `mcp`, `api.example.com` → `api`. Good enough for
+ * suggesting in an error message; we still require the caller to pass one
+ * explicitly because hostname-derived names collide easily.
+ */
+export function deriveAliasFromUrl(url: string): string | null {
+	try {
+		const host = new URL(url).hostname
+		const label = host.split(".")[0]
+		return label && label !== "" ? label : null
+	} catch {
+		return null
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,11 +176,42 @@ async function handleInstall(server: string | undefined, options: CliOptions) {
 	const { selectClient, selectServer, parseServerConfig } = await import(
 		"./utils/command-prompts"
 	)
-	const { installServer } = await import("./commands/mcp/install")
+	const {
+		installServer,
+		installRemoteUrlServer,
+		isHttpUrl,
+		deriveAliasFromUrl,
+	} = await import("./commands/mcp/install")
+	const { fatal } = await import("./lib/cli-error")
 
 	const selectedClient = await selectClient(options.client, "Install")
-	const selectedServer = await selectServer(server, selectedClient, undefined)
 	validateClient(selectedClient)
+
+	// URL inputs (e.g. toolbox endpoints, self-hosted MCPs) bypass the
+	// registry. Caller provides `--name` as the alias; we don't try to derive
+	// one because hostname-based names collide too easily across users'
+	// config files.
+	if (server && isHttpUrl(server)) {
+		const alias = options.name
+		if (!alias) {
+			const suggestion = deriveAliasFromUrl(server)
+			fatal(
+				`URL installs require an explicit \`--name <alias>\`${
+					suggestion ? ` (e.g. --name ${suggestion})` : ""
+				}. The alias is the key written under \`mcpServers\` in the client config.`,
+			)
+		}
+		// `fatal` returns `never` but the dynamic import above erases that
+		// signature, so TS can't narrow `alias` here — assert.
+		await installRemoteUrlServer(
+			server,
+			alias as string,
+			selectedClient as ValidClient,
+		)
+		return
+	}
+
+	const selectedServer = await selectServer(server, selectedClient, undefined)
 
 	const config: ServerConfig = options.config
 		? parseServerConfig(options.config)
@@ -611,7 +642,8 @@ Examples:
   smithery mcp add http://localhost:9090/mcp --id chrome
   smithery mcp add --id chrome -- npx -y @chromedevtools/chrome-devtools-mcp
   smithery mcp add https://server.smithery.ai/exa --id exa --name "Exa Search"
-  smithery mcp add anthropic/exa --client claude`,
+  smithery mcp add exa --client claude
+  smithery mcp add https://mcp.smithery.run/arjunkmrm --name toolbox --client librechat`,
 	)
 	.action(handleMcpAdd)
 

--- a/src/lib/client-config-io.ts
+++ b/src/lib/client-config-io.ts
@@ -697,3 +697,24 @@ export function formatServerConfig(
 			return createStdioConfig(qualifiedName)
 	}
 }
+
+/**
+ * Creates server configuration for an arbitrary remote MCP URL.
+ *
+ * For OAuth-capable clients, writes a direct `{type: "http", url}` block — the
+ * client handles auth on first connection. For non-OAuth clients, falls back
+ * to mcp-remote so the URL is reachable via stdio.
+ */
+export function formatRemoteUrlConfig(
+	url: string,
+	transportType: "http-oauth" | "http-proxy",
+): ConfiguredServer {
+	if (transportType === "http-oauth") {
+		return { type: "http", url, headers: {} }
+	}
+	const args = ["-y", "mcp-remote", url]
+	if (process.platform === "win32") {
+		return { command: "cmd", args: ["/c", "npx", ...args] }
+	}
+	return { command: "npx", args }
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,4 +1,4 @@
-import inquirer from "inquirer"
+import * as readline from "node:readline"
 import pc from "picocolors"
 import { uuidv7 } from "uuidv7"
 import { ANALYTICS_ENDPOINT } from "../constants"
@@ -10,6 +10,24 @@ import {
 	initializeSettings,
 	setAnalyticsConsent,
 } from "./smithery-settings"
+
+// One-line Y/N prompt using node:readline. Avoids inquirer 8.x's readline
+// pause-after-close path which throws ERR_USE_AFTER_CLOSE on Node 24+.
+function promptYesNo(message: string, defaultYes: boolean): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		})
+		const suffix = defaultYes ? " (Y/n) " : " (y/N) "
+		rl.question(`${message}${suffix}`, (answer) => {
+			rl.close()
+			const trimmed = answer.trim().toLowerCase()
+			if (trimmed === "") return resolve(defaultYes)
+			resolve(trimmed === "y" || trimmed === "yes")
+		})
+	})
+}
 
 // Session management
 type Session = {
@@ -94,17 +112,22 @@ export async function checkAnalyticsConsent(): Promise<void> {
 
 		/* Only ask if we haven't asked before and consent is false */
 		if (!askedConsent) {
-			try {
-				const { EnableAnalytics } = await inquirer.prompt([
-					{
-						type: "confirm",
-						name: "EnableAnalytics",
-						message: `Would you like to help improve Smithery by sending anonymized usage data?`,
-						default: true,
-					},
-				])
+			// Non-interactive shells (CI, piped stdin) can't answer the prompt.
+			// Persist `askedConsent: true` with consent=false so we don't keep
+			// asking on every invocation, and so the early return on the next
+			// run skips this whole block.
+			if (!process.stdin.isTTY) {
+				verbose("Non-interactive stdin — defaulting analytics consent to false")
+				await setAnalyticsConsent(false)
+				return
+			}
 
-				const result = await setAnalyticsConsent(EnableAnalytics)
+			try {
+				const enable = await promptYesNo(
+					"Would you like to help improve Smithery by sending anonymized usage data?",
+					true,
+				)
+				const result = await setAnalyticsConsent(enable)
 				if (!result.success) {
 					console.warn(
 						pc.yellow("[Smithery] Failed to save preference:"),
@@ -115,7 +138,6 @@ export async function checkAnalyticsConsent(): Promise<void> {
 					)
 				}
 			} catch (error) {
-				// Handle potential inquirer errors
 				console.warn(
 					pc.yellow("[Smithery] Failed to prompt for consent:"),
 					error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Why

Two compounding bugs hit users running the published CLI on Node 24:

1. **Consent prompt crashes** — `inquirer@8.2.4` calls `readline.pause()` after the interface is closed, which Node 24.15.0+ now throws as `ERR_USE_AFTER_CLOSE` instead of silently no-op'ing. Anyone with `askedConsent: false` in their settings hits this on the first command after upgrading Node.
2. **No way to install a toolbox / arbitrary remote MCP URL into a client config** — \`mcp add --client <c>\` runs through \`installServer\` which calls \`resolveServer\` against the registry, so toolbox endpoints (\`https://mcp.smithery.run/<ns>\`) and self-hosted MCPs 404.

## What

### Consent prompt (analytics.ts)
- Replace inquirer's confirm prompt with native \`node:readline\` for this one call. Targeted to avoid bumping inquirer 8 → 13 (ESM-only, breaking API across ~21 call sites — separate PR).
- If stdin is non-TTY (CI, piped), persist \`askedConsent: true\` with consent=false and skip the prompt entirely. Stops repeat prompts on every CI run.

### URL install (\`mcp add <url> --name <alias> --client <c>\`)
- New \`installRemoteUrlServer()\` skips registry resolution. Accepts an http(s) URL and a caller-provided alias.
- New \`formatRemoteUrlConfig()\` — OAuth-capable clients get \`{type: "http", url, headers: {}}\`; non-OAuth clients fall back to mcp-remote.
- \`handleInstall\` branches on URL detection and routes accordingly.
- Errors with \`--name\` suggestion if alias is missing; we deliberately don't auto-derive from hostname (collisions across users' configs).
- Errors if the client doesn't expose an http transport.

### Help text
- Added URL example to \`mcp add\` help.
- Tweaked existing example: \`anthropic/exa --client claude\` → \`exa --client claude\`.

## Verified

\`\`\`
$ node dist/index.js mcp add https://mcp.smithery.run/arjunkmrm --name toolbox --client librechat
✓ toolbox (https://mcp.smithery.run/arjunkmrm) successfully installed for librechat

$ cat ~/LibreChat/librechat.yaml
mcpServers:
  toolbox:
    type: http
    url: https://mcp.smithery.run/arjunkmrm
    headers: {}
\`\`\`

Non-TTY consent path verified: \`askedConsent: true\` is persisted, no crash, no prompt.

## Out of scope

- **Full inquirer migration to v13 / @inquirer/prompts.** ~21 call sites across the CLI use inquirer 8. Other prompts (\`selectClient\`, \`selectServer\`, \`promptForRestart\`) are still on inquirer 8 and may hit the same Node 24 readline bug. Targeted fix here unblocks the most common path (consent on every install). Migration is a separate PR.
- API-key auth for non-OAuth clients on URL installs. Today they get mcp-remote which handles auth client-side.

## Test plan

- [ ] \`smithery mcp add https://mcp.smithery.run/<ns> --name toolbox --client librechat\` writes a valid librechat.yaml block
- [ ] \`smithery mcp add https://... --client librechat\` (no --name) errors with a helpful suggestion
- [ ] \`smithery mcp add <ns>/<server> --client claude\` still works (registry path untouched)
- [ ] On Node 24, fresh settings.json (askedConsent=false) — interactive consent prompt no longer crashes
- [ ] CI / piped stdin — consent persists silently with consent=false