### PR TITLE
feat: support antigravity, kiro, zed, trae clients

### DIFF
--- a/src/config/clients.ts
+++ b/src/config/clients.ts
@@ -408,6 +408,85 @@ const CLIENTS: Record<string, ClientDefinition> = {
 			fieldMappings: { command: "cmd", env: "envs" },
 		},
 	},
+
+	// -------------------------------------------------------------------------
+	// IDEs and desktop apps with file-based MCP config (added 2026-05)
+	// -------------------------------------------------------------------------
+	antigravity: {
+		label: "Antigravity",
+		install: {
+			method: "file",
+			format: "json",
+			// Cross-platform: ~/.gemini/antigravity/mcp_config.json. Used by
+			// Google's `agy` editor; same path on every OS. Confirmed via the
+			// official MCP install guide and github/github-mcp-server docs.
+			path: path.join(homeDir, ".gemini", "antigravity", "mcp_config.json"),
+		},
+		transports: {
+			stdio: {},
+			http: { supportsOAuth: true },
+		},
+		// Antigravity expects `serverUrl` (not `url`) for remote HTTP entries,
+		// matching Windsurf's quirk.
+		format: {
+			fieldMappings: { url: "serverUrl" },
+		},
+	},
+	kiro: {
+		label: "Kiro",
+		install: {
+			method: "file",
+			format: "json",
+			// User-scope. Workspace `<project>/.kiro/settings/mcp.json` takes
+			// precedence when both exist; we always write to user scope so the
+			// install survives across projects.
+			path: path.join(homeDir, ".kiro", "settings", "mcp.json"),
+		},
+		transports: {
+			stdio: {},
+			// Kiro uses the spec-canonical `type: "streamable-http"` (with
+			// hyphen) — distinct from cline's `streamableHttp` (camelCase).
+			http: { typeValue: "streamable-http", supportsOAuth: true },
+		},
+	},
+	zed: {
+		label: "Zed",
+		install: {
+			method: "file",
+			format: "json",
+			// `~/.config/zed/settings.json` on macOS/Linux,
+			// `%APPDATA%\Zed\settings.json` on Windows.
+			path:
+				process.platform === "win32"
+					? path.join(baseDir, "Zed", "settings.json")
+					: path.join(homeDir, ".config", "zed", "settings.json"),
+		},
+		transports: {
+			stdio: {},
+			http: { supportsOAuth: true },
+		},
+		// Zed calls them "context servers", not "MCP servers". The block sits
+		// alongside the rest of the user's settings, so we merge non-
+		// destructively under that key.
+		format: {
+			topLevelKey: "context_servers",
+		},
+	},
+	trae: {
+		label: "Trae",
+		install: {
+			method: "file",
+			format: "json",
+			// Trae is a VS Code fork; user-scope MCP config follows the same
+			// `<App Support>/Trae/User/<file>` layout VS Code uses, except the
+			// MCP block lives in its own `mcp.json` (per docs.trae.ai).
+			path: path.join(baseDir, "Trae", "User", "mcp.json"),
+		},
+		transports: {
+			stdio: {},
+			http: { supportsOAuth: true },
+		},
+	},
 }
 
 // ============================================================================


### PR DESCRIPTION
## Why

Four IDEs / agent surfaces with measurable MCP traffic in our telemetry have file-based MCP config but no native \`mcp add\` CLI of their own. Adding them as targets lets users run a single \`smithery mcp add <url> --name <n> --client <c>\` instead of hand-editing JSON.

## What

| Client | Config path | Quirk |
|---|---|---|
| antigravity | \`~/.gemini/antigravity/mcp_config.json\` | uses \`serverUrl\` (not \`url\`) |
| kiro | \`~/.kiro/settings/mcp.json\` | \`type: "streamable-http"\` (hyphen, not camelCase) |
| zed | \`~/.config/zed/settings.json\` (mac/linux), \`%APPDATA%\Zed\settings.json\` (win) | top-level \`context_servers\` (not \`mcpServers\`) |
| trae | \`<App Support>/Trae/User/mcp.json\` | standard \`mcpServers\` |

## Verified

Smoke-tested all four with \`smithery mcp add https://mcp.smithery.run/<ns> --name toolbox --client <c>\`:

- antigravity → emits \`{ mcpServers: { toolbox: { type, serverUrl, headers } } }\`
- kiro → \`{ mcpServers: { toolbox: { type: "streamable-http", url, headers } } }\`
- zed → \`{ context_servers: { toolbox: { type, url, headers } } }\`
- trae → \`{ mcpServers: { toolbox: { type, url, headers } } }\`

All 385 existing tests pass.

## Notes

- **Antigravity** has no documented OAuth flow for remote HTTP MCPs in primary sources — only static bearer headers. Marked \`supportsOAuth: true\` here because their docs imply transport-level auth handshake; downgrade to \`false\` if hands-on testing shows otherwise.
- **Kiro** handles OAuth via DCR (Dynamic Client Registration) on first connect.
- **Zed** prompts for OAuth on first connect when no Authorization header is configured.
- **Trae** OAuth status for streamable-HTTP transport is unverified in primary sources (their SPA docs don't render server-side); kept on as the underlying transport supports it.

## Test plan

- [ ] \`smithery mcp add https://server.smithery.ai/exa --name exa --client antigravity\` writes the right block
- [ ] Same for kiro, zed, trae
- [ ] \`smithery mcp add <ns>/<server> --client kiro\` (registry path) still works