### PR TITLE
fix: pin release-please scan boundary to v1.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,9 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"packages": {
-		".": {}
+		".": {
+			"last-release-sha": "5195545ed728bd39b234fd9bc9ca0d13c03673ec"
+		}
 	},
 	"include-v-in-tag": true,
 	"include-component-in-tag": false,


### PR DESCRIPTION
## Why

PR #759 keeps proposing version `1.0.0` (downgrade from current `1.0.1`) and pulls a massive historical changelog into the diff. Root cause: commit [683a982](https://github.com/smithery-ai/cli/commit/683a982) ("chore: pin first release to 1.0.0") carries a `Release-As: 1.0.0` footer that was meant to anchor the rebrand release. That footer should have been consumed once 1.0.0 shipped, but release-please keeps re-discovering it on every scan and overriding the computed version.

## What

Adds `last-release-sha` to the package config, pinned to the v1.0.1 release commit (`5195545`). This tells release-please anything before this SHA is already released — don't scan it. Permanently moves the stale Release-As footer out of scan range.

## Expected effect

After this lands, release-please will regenerate PR #759 (or open a new one) computing the next version correctly from commits after v1.0.1 — should be `1.1.0` (we have unreleased feat commits) or `1.0.2`.

## Test plan

- [ ] Merge this PR
- [ ] Verify release-please workflow runs and updates #759
- [ ] Confirm new version proposed is >= 1.0.2 and changelog only includes #761, #762