### PR TITLE
chore: unblock release-please, force next release to 1.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"packages": {
-		".": {
-			"last-release-sha": "5195545ed728bd39b234fd9bc9ca0d13c03673ec"
-		}
+		".": {}
 	},
 	"include-v-in-tag": true,
 	"include-component-in-tag": false,


### PR DESCRIPTION
## Why

PR #763 attempted to use `last-release-sha` to skip the stale `Release-As: 1.0.0` footer in commit 683a982, but release-please's tag-based detection takes priority over `last-release-sha` when tags exist, so the field had no effect. PR #759 still proposes a 1.0.0 downgrade.

## What

- Reverts the no-op config change from #763.
- Adds `Release-As: 1.1.0` footer below — release-please uses the **last** `Release-As:` footer in scan range, so this overrides 683a982.

1.1.0 reflects the natural conventional-commit bump (feat in #762, fix in #761) from current 1.0.1.

## Note for merge

Important: squash-merge must preserve the `Release-As: 1.1.0` footer in the squash commit body. The default `gh pr merge --squash` behavior keeps the PR body, so this footer will land. If using the GitHub UI, ensure the footer stays in the squash commit message.

Release-As: 1.1.0