### PR TITLE
chore: hide chores from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
 		{ "type": "perf", "section": "Performance Improvements" },
 		{ "type": "revert", "section": "Reverts" },
 		{ "type": "docs", "section": "Documentation" },
-		{ "type": "chore", "section": "Chores" },
+		{ "type": "chore", "section": "Chores", "hidden": true },
 		{ "type": "refactor", "section": "Refactors" },
 		{ "type": "test", "section": "Tests", "hidden": true },
 		{ "type": "build", "section": "Build System", "hidden": true },


### PR DESCRIPTION
## Summary
- hide `chore` entries in release-please config so chore-only commits do not create patch release PRs
- preserves the repaired v1.1.0 changelog/release body while preventing the bogus 1.1.1 release PR from coming back

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('release-please-config.json','utf8'))"`
- pre-push `biome check`, `build`, and `vitest run` passed

BEGIN_COMMIT_OVERRIDE
ci: hide chores from release-please
END_COMMIT_OVERRIDE